### PR TITLE
Ticket 1025243 Ready for Review

### DIFF
--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -114,26 +114,36 @@ if ($RebootCount -eq $null) {
     Write-Host "Reboot count was null, setting this to 0."
 }
 
+Write-Host "The reboot day for this endpoint is $RebootDay"
+
 $now = Get-Date
-if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd -and $RebootCount -lt $RebootThreshold) {
-    Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. Rebooting the computer..."
-    $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
-    Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
-    # Start-Sleep -Seconds $randomSleep  # Sleep for a random duration between 1 and 90 minutes **LEGACY LOGIC** 
-    $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
-    & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
+if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
+    if ($RebootCount -lt $RebootThreshold) {
+        Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
+        $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
+        Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
+        # Start-Sleep -Seconds $randomSleep  # Sleep for a random duration between 1 and 90 minutes **LEGACY LOGIC** 
+        $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
+        & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
 
-    $RebootCount = $RebootCount + 1
+        $RebootCount = $RebootCount + 1
+    } else {
+        Write-Host "Reboot threshold has been meant. Not rebooting. Reboot Count: $RebootCount. Reboot Threshold: $RebootThreshold."
+    }
 
-} elseif ($RebootDay -eq "Everyday" -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd -and $RebootCount -lt $RebootThreshold) {
-    Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. Rebooting the computer..."
-    $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
-    Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
-    # Start-Sleep -Seconds $randomSleep  # Sleep for a random duration between 1 and 90 minutes **LEGACY LOGIC** 
-    $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
-    & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
+} elseif ($RebootDay -eq "Everyday" -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
+    if ($RebootCount -lt $RebootThreshold) {
+        Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
+        $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
+        Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
+        # Start-Sleep -Seconds $randomSleep  # Sleep for a random duration between 1 and 90 minutes **LEGACY LOGIC** 
+        $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
+        & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
 
-    $RebootCount = $RebootCount + 1
+        $RebootCount = $RebootCount + 1
+    } else {
+        Write-Host "Reboot threshold has been meant. Not rebooting. Reboot Count: $RebootCount. Reboot Threshold: $RebootThreshold."
+    }
 
 } else {
     Write-Host "It is not between $RebootHourStart and $RebootHourEnd on a $RebootDay. Not rebooting."

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -92,15 +92,15 @@ $ServerRole = (Get-WindowsFeature -Name Hyper-V).Installed
     if ($RebootDay -eq $null){
         $RebootDay = "Everyday"
     }
-} elseif ($RebootDay -eq "Manual") {
-    Write-Host "Reboots are done manually for this endpoint. Exiting."
-    Exit 0
-}
 } else {
     Write-Output "This endpoint type is unknown or unsupported."
     Exit 0
 }
 
+if ($RebootDay -eq "Manual") {
+    Write-Host "Reboots are done manually for this endpoint. Exiting."
+    Exit 0
+}
 
 if ($RebootDay -eq $null) {
     $RebootDay = "Everyday"

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -95,7 +95,7 @@ if ($RebootDay -eq $null) {
 }
 
 if ($RebootHourStart -eq $null) {
-    $RebootHourStart = 12
+    $RebootHourStart = 0
     Write-Host "Reboot Hour Start is null so we are setting the default to $RebootHourStart."
 }
 

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -82,7 +82,7 @@ $ServerRole = (Get-WindowsFeature -Name Hyper-V).Installed
     } else {
         Write-Output "This endpoint is a regular Windows Server."
         $RebootDay = $ServerRebootDay
-        if ($RebootDay -eq $nulll) {
+        if ($RebootDay -eq $null) {
             $RebootDay = "Saturday"
         }
     }
@@ -140,7 +140,7 @@ if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $no
         $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
         & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
 
-        $RebootCount = $RebootCount + 1
+        #$RebootCount = $RebootCount + 1
     } else {
         Write-Host "Reboot threshold has been meant. Not rebooting. Reboot Count: $RebootCount. Reboot Threshold: $RebootThreshold."
     }
@@ -154,7 +154,7 @@ if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $no
         $ShutdownPath = $ENV:WINDIR + "\System32\shutdown.exe"  
         & $ShutdownPath -r -t $RandomSleep -f -c "Your MSP is rebooting this endpoint for pending maintenance in $($RandomSleep/60) minutes. Reboot time range script."
 
-        $RebootCount = $RebootCount + 1
+        #$RebootCount = $RebootCount + 1
     } else {
         Write-Host "Reboot threshold has been meant. Not rebooting. Reboot Count: $RebootCount. Reboot Threshold: $RebootThreshold."
     }

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -1,8 +1,8 @@
 ## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
 # $WorkstationRebootDay needs declared in RMM, else defaults to Everyday
-# $ServerRebootDay needs declared in RMM, else defaults to Everyday
-# $HypervisorRebootDay needs declared in RMM, else defaults to Everyday
+# $ServerRebootDay needs declared in RMM, else defaults to Saturday
+# $HypervisorRebootDay needs declared in RMM, else defaults to Tuesday
 # $RebootHourStart needs declared in RMM, else defaults to 3 AM
 # $RebootHourEnd needs declared in RMM, else defaults to 5 AM
 # $RebootStaggerMax, needs declared in RMM, else defaults to 5400

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -76,13 +76,22 @@ $ServerRole = (Get-WindowsFeature -Name Hyper-V).Installed
     if ($ServerRole) {
         Write-Output "This endpoint is a Hyper-V host (Windows Server with Hyper-V role)."
         $RebootDay = $HypervisorRebootDay
+        if ($RebootDay -eq $null) {
+            $RebootDay = "Tuesday"
+        }
     } else {
         Write-Output "This endpoint is a regular Windows Server."
         $RebootDay = $ServerRebootDay
+        if ($RebootDay -eq $nulll) {
+            $RebootDay = "Saturday"
+        }
     }
 } elseif ($OsInfo.Caption -match "Windows 10|Windows 11") {
     Write-Output "This endpoint is a workstation."
     $RebootDay = $WorkstationRebootDay
+    if ($RebootDay -eq $null){
+        $RebootDay = "Everyday"
+    }
 } else {
     Write-Output "This endpoint type is unknown or unsupported."
     Exit 0
@@ -95,12 +104,12 @@ if ($RebootDay -eq $null) {
 }
 
 if ($RebootHourStart -eq $null) {
-    $RebootHourStart = 12
+    $RebootHourStart = 3
     Write-Host "Reboot Hour Start is null so we are setting the default to $RebootHourStart."
 }
 
 if ($RebootHourEnd -eq $null) {
-    $RebootHourEnd = 23
+    $RebootHourEnd = 5
     Write-Host "Reboot Hour End is null so we are setting the default to $RebootHourEnd."
 }
  

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -95,7 +95,7 @@ if ($RebootDay -eq $null) {
 }
 
 if ($RebootHourStart -eq $null) {
-    $RebootHourStart = 0
+    $RebootHourStart = 12
     Write-Host "Reboot Hour Start is null so we are setting the default to $RebootHourStart."
 }
 
@@ -103,10 +103,15 @@ if ($RebootHourEnd -eq $null) {
     $RebootHourEnd = 23
     Write-Host "Reboot Hour End is null so we are setting the default to $RebootHourEnd."
 }
-
+ 
 if ($RebootStaggerMax -eq $null) {
     $RebootStaggerMax = 5400
     Write-Host "Reboot Stagger Max is null sow we are setting the default to $RebootStaggerMax."
+}
+
+if ($RebootCount -eq $null) {
+    $RebootCount = 0
+    Write-Host "Reboot count was null, setting this to 0."
 }
 
 $now = Get-Date

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -118,7 +118,7 @@ Write-Host "The reboot day for this endpoint is $RebootDay"
 
 $now = Get-Date
 if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
-    if ($RebootCount -lt $RebootThreshold) {
+    if ($RebootCount -gt $RebootThreshold) {
         Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
         $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
         Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
@@ -132,7 +132,7 @@ if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $no
     }
 
 } elseif ($RebootDay -eq "Everyday" -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
-    if ($RebootCount -lt $RebootThreshold) {
+    if ($RebootCount -gt $RebootThreshold) {
         Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
         $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
         Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -15,7 +15,7 @@
 
 # Getting input from user if not running from RMM else set variables from RMM.
 
-$ScriptLogName = "msft-windows-idle-time-reboot.log"
+$ScriptLogName = "msft-windows-reboot-maintenance-window.log"
 
 if ($RMM -ne 1) {
     $ValidInput = 0
@@ -107,6 +107,11 @@ if ($RebootHourEnd -eq $null) {
 if ($RebootStaggerMax -eq $null) {
     $RebootStaggerMax = 5400
     Write-Host "Reboot Stagger Max is null sow we are setting the default to $RebootStaggerMax."
+}
+
+if ($RebootThreshold -eq $null) {
+    $RebootThreshold = 50
+    Write-Host "Reboot threshold was null, setting this to 50."
 }
 
 if ($RebootCount -eq $null) {

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -123,7 +123,7 @@ Write-Host "The reboot day for this endpoint is $RebootDay"
 
 $now = Get-Date
 if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
-    if ($RebootCount -gt $RebootThreshold) {
+    if ($RebootCount -le $RebootThreshold) {
         Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
         $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
         Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."
@@ -137,7 +137,7 @@ if ($now.DayOfWeek -eq '$RebootDay' -and $now.Hour -ge $RebootHourStart -and $no
     }
 
 } elseif ($RebootDay -eq "Everyday" -and $now.Hour -ge $RebootHourStart -and $now.Hour -lt $RebootHourEnd) {
-    if ($RebootCount -gt $RebootThreshold) {
+    if ($RebootCount -le $RebootThreshold) {
         Write-Host "It's between $RebootHourStart and $RebootHourEnd on $RebootDay. We're under the $RebootThresholdl with reboot count $RebootCount. Rebooting the computer..."
         $RandomSleep = Get-Random -Minimum 60 -Maximum $RebootStaggerMax
         Write-Host "Sleeping for $($randomSleep/60) minutes before rebooting..."

--- a/msft-windows/msft-windows-reboot-time-range.ps1
+++ b/msft-windows/msft-windows-reboot-time-range.ps1
@@ -92,6 +92,10 @@ $ServerRole = (Get-WindowsFeature -Name Hyper-V).Installed
     if ($RebootDay -eq $null){
         $RebootDay = "Everyday"
     }
+} elseif ($RebootDay -eq "Manual") {
+    Write-Host "Reboots are done manually for this endpoint. Exiting."
+    Exit 0
+}
 } else {
     Write-Output "This endpoint type is unknown or unsupported."
     Exit 0


### PR DESCRIPTION
Hi all,

I made adjustments to this script to honor reboot threshold when reboot count is accessible and shared globally among all endpoints. Currently a global information field isn't available in Ninja for all endpoints to share to utilize this. I disabled the counting for now until this is available in Ninja. It is commented out on lines 143 and 157.

I also added an everyday option to workstations and defaulted this to everyday.

I updated hypervisors and servers to be rebooted by default hypervisors Tuesday and servers Saturday.

With this script, all endpoints globaly:
-Will reboot between 3 AM and 5 AM any day unless the reboot window is manually set in Ninja location.
-Reboots are staggered globally and randomly between this time frame with a stagger of seconds of 60-5400.
-This script will run without "a pending reboot" and must be conditionally detected in the RMM.

With this script now workstations should reboot:
-By default everyday unless sepecified in Ninja Location for a specific day.

With this script now servers should reboot:
-By default Saturday unless specified in Ninja Location for a specific day.

With this scrip now hypervisors specifically Hyper-V should reboot:
-By default Tuesday unless specified in Ninja Location ffor a specific day.