### PR TITLE
Create RemoveDuplicateLocalAdmin.ps1

### DIFF
--- a/msft-windows/RemoveDuplicateLocalAdmin.ps1
+++ b/msft-windows/RemoveDuplicateLocalAdmin.ps1
@@ -1,3 +1,45 @@
+## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "EnterLogNameHere.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else { 
+    # Store the logs in the RMMScriptPath
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+        
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+        
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }   
+
+
+    
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
 # Script to clean up duplicate profile registry entries
 # Author: Joseph Owens
 # Description: Identifies and removes invalid profile registry entries that have duplicate ProfileImagePath values
@@ -99,3 +141,11 @@ foreach ($path in $profilePaths.Keys) {
 
 Write-Log "`nProfile Cleanup Script completed"
 Write-Log "Review the log file at: $logFile" 
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+
+Stop-Transcript


### PR DESCRIPTION
This script identifies duplicate reg keys in the profilelist and then queries the local SAM database to identify the SID of the true local admin profile. It then removes any duplicates. The duplicate regkeys have consistently caused failures when performing windows 11 upgrades and this should resolve this issue.