### PR TITLE
Fix Stop-Transcript error when transcript not active

### DIFF
--- a/msft-windows/msft-windows-disable-core-isolation.ps1
+++ b/msft-windows/msft-windows-disable-core-isolation.ps1
@@ -48,7 +48,13 @@ if (!(Test-Path $logDir)) {
     New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 }
 
-Start-Transcript -Path $LogPath
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
 
 Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
@@ -65,7 +71,7 @@ try {
 
     if (-not $isAdmin) {
         Write-Error "This script must be run as Administrator to modify system security settings."
-        Stop-Transcript
+        if ($TranscriptStarted) { Stop-Transcript }
         exit 1
     }
 
@@ -290,8 +296,8 @@ try {
 } catch {
     Write-Error "An error occurred: $($_.Exception.Message)"
     Write-Host "Error details: $($_.Exception)" -ForegroundColor Red
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     exit 1
 }
 
-Stop-Transcript
+if ($TranscriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-disable-core-isolation.ps1
+++ b/msft-windows/msft-windows-disable-core-isolation.ps1
@@ -212,9 +212,33 @@ try {
 
     Write-Host ""
 
-    # Note: We intentionally do NOT disable the hypervisor (bcdedit hypervisorlaunchtype Off)
-    # because some GPU drivers depend on it being present. Disabling just HVCI/VBS via registry
-    # is sufficient to remove the security overhead while maintaining driver compatibility.
+    # Step 7: Ensure hypervisor is enabled (some GPU drivers depend on it)
+    Write-Host "Step 7: Ensuring hypervisor is enabled (for GPU driver compatibility)..." -ForegroundColor Yellow
+
+    $hypervisorRestored = $false
+    try {
+        $result = bcdedit /set "{current}" hypervisorlaunchtype Auto 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Hypervisor Launch Type set to Auto" -ForegroundColor Green
+            $hypervisorRestored = $true
+        } else {
+            Write-Host "  Hypervisor setting: $result" -ForegroundColor Gray
+        }
+    } catch {
+        Write-Host "  Could not modify hypervisor launch type" -ForegroundColor Gray
+    }
+
+    try {
+        # Remove vsmlaunchtype if it was previously set to Off
+        $result = bcdedit /deletevalue "{current}" vsmlaunchtype 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  VSM Launch Type reset to default" -ForegroundColor Green
+        }
+    } catch {
+        # Ignore - may not exist
+    }
+
+    Write-Host ""
 
     # Final summary - report actual status
     Write-Host "=== Configuration Summary ===" -ForegroundColor Cyan
@@ -238,7 +262,11 @@ try {
     } else {
         Write-Host "Kernel DMA Protection: Failed to configure" -ForegroundColor Yellow
     }
-    Write-Host "Hypervisor: Preserved (for GPU driver compatibility)" -ForegroundColor Cyan
+    if ($hypervisorRestored) {
+        Write-Host "Hypervisor: Enabled (for GPU driver compatibility)" -ForegroundColor Green
+    } else {
+        Write-Host "Hypervisor: Could not verify (check manually if issues occur)" -ForegroundColor Yellow
+    }
     Write-Host "===============================" -ForegroundColor Cyan
     Write-Host ""
 

--- a/msft-windows/msft-windows-disable-core-isolation.ps1
+++ b/msft-windows/msft-windows-disable-core-isolation.ps1
@@ -83,7 +83,6 @@ try {
     $vbsSuccess = $false
     $credGuardSuccess = $false
     $dmaSuccess = $false
-    $vsmSuccess = $false
 
     # Step 1: Check current Core Isolation status
     Write-Host "Step 1: Checking current Core Isolation status..." -ForegroundColor Yellow
@@ -213,36 +212,9 @@ try {
 
     Write-Host ""
 
-    # Step 7: Remove UEFI lock if present (requires bcdedit)
-    Write-Host "Step 7: Removing UEFI lock on VBS..." -ForegroundColor Yellow
-
-    try {
-        # Disable Secure Launch
-        $result = bcdedit /set "{current}" vsmlaunchtype Off 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "  VSM Launch Type set to Off" -ForegroundColor Green
-            $vsmSuccess = $true
-        } else {
-            Write-Host "  VSM Launch Type: $result" -ForegroundColor Gray
-        }
-    } catch {
-        Write-Host "  Could not modify VSM launch type" -ForegroundColor Gray
-    }
-
-    try {
-        # Disable Hypervisor launch
-        $result = bcdedit /set "{current}" hypervisorlaunchtype Off 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "  Hypervisor Launch Type set to Off" -ForegroundColor Green
-            Write-Host "  WARNING: This will disable Hyper-V, WSL2, and Windows Sandbox!" -ForegroundColor Yellow
-        } else {
-            Write-Host "  Hypervisor setting: $result" -ForegroundColor Gray
-        }
-    } catch {
-        Write-Host "  Could not modify hypervisor launch type" -ForegroundColor Gray
-    }
-
-    Write-Host ""
+    # Note: We intentionally do NOT disable the hypervisor (bcdedit hypervisorlaunchtype Off)
+    # because some GPU drivers depend on it being present. Disabling just HVCI/VBS via registry
+    # is sufficient to remove the security overhead while maintaining driver compatibility.
 
     # Final summary - report actual status
     Write-Host "=== Configuration Summary ===" -ForegroundColor Cyan
@@ -266,11 +238,7 @@ try {
     } else {
         Write-Host "Kernel DMA Protection: Failed to configure" -ForegroundColor Yellow
     }
-    if ($vsmSuccess) {
-        Write-Host "VSM/Hypervisor: Set to Off" -ForegroundColor Green
-    } else {
-        Write-Host "VSM/Hypervisor: Could not modify (may require manual BIOS change)" -ForegroundColor Yellow
-    }
+    Write-Host "Hypervisor: Preserved (for GPU driver compatibility)" -ForegroundColor Cyan
     Write-Host "===============================" -ForegroundColor Cyan
     Write-Host ""
 
@@ -290,7 +258,7 @@ try {
     Write-Host "IMPORTANT NOTES:" -ForegroundColor Yellow
     Write-Host "  - A system restart is REQUIRED for changes to take effect" -ForegroundColor Yellow
     Write-Host "  - If UEFI locked, may require BIOS changes to fully disable" -ForegroundColor Yellow
-    Write-Host "  - Hyper-V, WSL2, and Windows Sandbox will be disabled" -ForegroundColor Yellow
+    Write-Host "  - Hyper-V, WSL2, and Windows Sandbox will still work" -ForegroundColor Green
     Write-Host "  - This reduces security - only use on systems that need it" -ForegroundColor Yellow
 
 } catch {

--- a/msft-windows/msft-windows-disable-mpo.ps1
+++ b/msft-windows/msft-windows-disable-mpo.ps1
@@ -42,7 +42,13 @@ if ($RMM -ne 1) {
 
 # Start the script logic here.
 
-Start-Transcript -Path $LogPath
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
 
 Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
@@ -59,7 +65,7 @@ try {
 
     if (-not $isAdmin) {
         Write-Error "This script must be run as Administrator to modify system registry."
-        Stop-Transcript
+        if ($TranscriptStarted) { Stop-Transcript }
         exit 1
     }
 
@@ -82,7 +88,7 @@ try {
         Write-Host "  OverlayTestMode = 5 (MPO Disabled)" -ForegroundColor Green
     } catch {
         Write-Host "  Failed to set OverlayTestMode: $($_.Exception.Message)" -ForegroundColor Red
-        Stop-Transcript
+        if ($TranscriptStarted) { Stop-Transcript }
         exit 1
     }
 
@@ -125,8 +131,8 @@ try {
 } catch {
     Write-Error "An error occurred: $($_.Exception.Message)"
     Write-Host "Error details: $($_.Exception)" -ForegroundColor Red
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     exit 1
 }
 
-Stop-Transcript
+if ($TranscriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-enable-core-isolation.ps1
+++ b/msft-windows/msft-windows-enable-core-isolation.ps1
@@ -1,0 +1,242 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $Description
+
+# This script re-enables Core Isolation (Memory Integrity / HVCI)
+# Use this to reverse the effects of msft-windows-disable-core-isolation.ps1
+# Note: On some older machines, disabling Core Isolation can cause screen flickering - this script fixes that.
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "msft-windows-enable-core-isolation.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -ne $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "Windows Core Isolation Enable"
+    }
+}
+
+# Start the script logic here.
+
+# Ensure log directory exists before starting transcript
+$logDir = Split-Path -Path $LogPath -Parent
+if (!(Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM `n"
+
+Write-Host "=== Windows Core Isolation Enable Script ===" -ForegroundColor Cyan
+Write-Host "This script re-enables Core Isolation (Memory Integrity/HVCI)." -ForegroundColor White
+Write-Host ""
+
+try {
+    # Check if running as administrator
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if (-not $isAdmin) {
+        Write-Error "This script must be run as Administrator to modify system security settings."
+        if ($TranscriptStarted) { Stop-Transcript }
+        exit 1
+    }
+
+    Write-Host "Running with Administrator privileges" -ForegroundColor Green
+    Write-Host ""
+
+    # Track success/failure of each operation
+    $hvciSuccess = $false
+    $vbsSuccess = $false
+    $hypervisorSuccess = $false
+
+    # Step 1: Check current Core Isolation status
+    Write-Host "Step 1: Checking current Core Isolation status..." -ForegroundColor Yellow
+
+    try {
+        $deviceGuard = Get-CimInstance -ClassName Win32_DeviceGuard -Namespace root\Microsoft\Windows\DeviceGuard -ErrorAction SilentlyContinue
+        if ($deviceGuard) {
+            Write-Host "  VBS Status: $($deviceGuard.VirtualizationBasedSecurityStatus)" -ForegroundColor Gray
+            Write-Host "  HVCI Status: $($deviceGuard.CodeIntegrityPolicyEnforcementStatus)" -ForegroundColor Gray
+        }
+    } catch {
+        Write-Host "  Could not query current status" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+
+    # Step 2: Enable Memory Integrity (HVCI)
+    Write-Host "Step 2: Enabling Memory Integrity (HVCI)..." -ForegroundColor Yellow
+
+    $hvciPath = "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity"
+
+    if (!(Test-Path $hvciPath)) {
+        New-Item -Path $hvciPath -Force | Out-Null
+        Write-Host "  Created registry path: $hvciPath" -ForegroundColor Gray
+    }
+
+    try {
+        Set-ItemProperty -Path $hvciPath -Name "Enabled" -Value 1 -Type DWord -Force
+        Write-Host "  HVCI Enabled = 1 (Enabled)" -ForegroundColor Green
+        $hvciSuccess = $true
+    } catch {
+        Write-Host "  Failed to enable HVCI: $($_.Exception.Message)" -ForegroundColor Red
+    }
+
+    try {
+        # Remove the WasEnabledBy value if it exists (let Windows manage it)
+        Remove-ItemProperty -Path $hvciPath -Name "WasEnabledBy" -Force -ErrorAction SilentlyContinue
+        Write-Host "  Cleared WasEnabledBy (Windows will manage)" -ForegroundColor Green
+    } catch {
+        # Ignore - may not exist
+    }
+
+    Write-Host ""
+
+    # Step 3: Enable Virtualization Based Security (VBS)
+    Write-Host "Step 3: Enabling Virtualization Based Security (VBS)..." -ForegroundColor Yellow
+
+    $deviceGuardPath = "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard"
+
+    if (!(Test-Path $deviceGuardPath)) {
+        New-Item -Path $deviceGuardPath -Force | Out-Null
+    }
+
+    try {
+        Set-ItemProperty -Path $deviceGuardPath -Name "EnableVirtualizationBasedSecurity" -Value 1 -Type DWord -Force
+        Write-Host "  EnableVirtualizationBasedSecurity = 1 (Enabled)" -ForegroundColor Green
+        $vbsSuccess = $true
+    } catch {
+        Write-Host "  Failed to enable VBS: $($_.Exception.Message)" -ForegroundColor Red
+    }
+
+    try {
+        # Set to require Secure Boot and DMA protection (value 3)
+        # Value 1 = Secure Boot only, Value 3 = Secure Boot + DMA Protection
+        Set-ItemProperty -Path $deviceGuardPath -Name "RequirePlatformSecurityFeatures" -Value 1 -Type DWord -Force
+        Write-Host "  RequirePlatformSecurityFeatures = 1 (Secure Boot)" -ForegroundColor Green
+    } catch {
+        Write-Host "  Failed to set RequirePlatformSecurityFeatures: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+
+    # Step 4: Re-enable Hypervisor (required for VBS)
+    Write-Host "Step 4: Re-enabling Hypervisor..." -ForegroundColor Yellow
+
+    try {
+        $result = bcdedit /set "{current}" hypervisorlaunchtype Auto 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Hypervisor Launch Type set to Auto" -ForegroundColor Green
+            $hypervisorSuccess = $true
+        } else {
+            Write-Host "  Hypervisor setting: $result" -ForegroundColor Gray
+        }
+    } catch {
+        Write-Host "  Could not modify hypervisor launch type" -ForegroundColor Gray
+    }
+
+    try {
+        $result = bcdedit /deletevalue "{current}" vsmlaunchtype 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  VSM Launch Type reset to default" -ForegroundColor Green
+        } else {
+            Write-Host "  VSM setting: $result" -ForegroundColor Gray
+        }
+    } catch {
+        Write-Host "  Could not reset VSM launch type" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+
+    # Step 5: Remove DMA Protection policy override (restore default)
+    Write-Host "Step 5: Restoring Kernel DMA Protection defaults..." -ForegroundColor Yellow
+
+    $dmaGuardPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Kernel DMA Protection"
+
+    try {
+        if (Test-Path $dmaGuardPath) {
+            Remove-ItemProperty -Path $dmaGuardPath -Name "DeviceEnumerationPolicy" -Force -ErrorAction SilentlyContinue
+            Write-Host "  Removed DMA policy override (Windows default restored)" -ForegroundColor Green
+        } else {
+            Write-Host "  No DMA policy override found (already default)" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "  Could not remove DMA policy: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+
+    # Final summary
+    Write-Host "=== Configuration Summary ===" -ForegroundColor Cyan
+    if ($hvciSuccess) {
+        Write-Host "Memory Integrity (HVCI): Enabled" -ForegroundColor Green
+    } else {
+        Write-Host "Memory Integrity (HVCI): Failed to enable" -ForegroundColor Red
+    }
+    if ($vbsSuccess) {
+        Write-Host "Virtualization Based Security (VBS): Enabled" -ForegroundColor Green
+    } else {
+        Write-Host "Virtualization Based Security (VBS): Failed to enable" -ForegroundColor Red
+    }
+    if ($hypervisorSuccess) {
+        Write-Host "Hypervisor: Set to Auto" -ForegroundColor Green
+    } else {
+        Write-Host "Hypervisor: Could not modify" -ForegroundColor Yellow
+    }
+    Write-Host "===============================" -ForegroundColor Cyan
+    Write-Host ""
+
+    # Determine overall success
+    $overallSuccess = $hvciSuccess -and $vbsSuccess
+    if ($overallSuccess) {
+        Write-Host "Core Isolation re-enabled successfully!" -ForegroundColor Green
+    } else {
+        Write-Host "Core Isolation partially enabled - some operations failed" -ForegroundColor Yellow
+    }
+    Write-Host ""
+    Write-Host "Security features restored:" -ForegroundColor Cyan
+    Write-Host "  - Memory Integrity protection against kernel exploits" -ForegroundColor White
+    Write-Host "  - Virtualization Based Security isolation" -ForegroundColor White
+    Write-Host "  - Hyper-V, WSL2, and Windows Sandbox support" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Note: A system restart is REQUIRED for changes to take effect." -ForegroundColor Yellow
+
+} catch {
+    Write-Error "An error occurred: $($_.Exception.Message)"
+    Write-Host "Error details: $($_.Exception)" -ForegroundColor Red
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}
+
+if ($TranscriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-enable-mpo.ps1
+++ b/msft-windows/msft-windows-enable-mpo.ps1
@@ -1,0 +1,146 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $Description
+
+# This script re-enables Multiplane Overlay (MPO) by removing the OverlayTestMode registry value.
+# Use this to reverse the effects of msft-windows-disable-mpo.ps1
+# Note: On some older machines, disabling MPO can cause screen flickering - this script fixes that.
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "msft-windows-enable-mpo.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -ne $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "Windows Multiplane Overlay (MPO) Enable"
+    }
+}
+
+# Start the script logic here.
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM `n"
+
+Write-Host "=== Windows Multiplane Overlay (MPO) Enable Script ===" -ForegroundColor Cyan
+Write-Host "This script re-enables MPO by removing the OverlayTestMode registry value." -ForegroundColor White
+Write-Host ""
+
+try {
+    # Check if running as administrator
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if (-not $isAdmin) {
+        Write-Error "This script must be run as Administrator to modify system registry."
+        if ($TranscriptStarted) { Stop-Transcript }
+        exit 1
+    }
+
+    Write-Host "Running with Administrator privileges" -ForegroundColor Green
+    Write-Host ""
+
+    # Step 1: Check current MPO status
+    Write-Host "Step 1: Checking current MPO status..." -ForegroundColor Yellow
+
+    $dwmPath = "HKLM:\SOFTWARE\Microsoft\Windows\Dwm"
+
+    if (!(Test-Path $dwmPath)) {
+        Write-Host "  Registry path does not exist: $dwmPath" -ForegroundColor Yellow
+        Write-Host "  MPO is already enabled (default state)." -ForegroundColor Green
+        if ($TranscriptStarted) { Stop-Transcript }
+        exit 0
+    }
+
+    $currentValue = $null
+    try {
+        $currentValue = Get-ItemProperty -Path $dwmPath -Name "OverlayTestMode" -ErrorAction Stop
+        Write-Host "  Current OverlayTestMode = $($currentValue.OverlayTestMode)" -ForegroundColor Yellow
+    } catch {
+        Write-Host "  OverlayTestMode registry value not found." -ForegroundColor Yellow
+        Write-Host "  MPO is already enabled (default state)." -ForegroundColor Green
+        if ($TranscriptStarted) { Stop-Transcript }
+        exit 0
+    }
+
+    Write-Host ""
+
+    # Step 2: Remove OverlayTestMode to re-enable MPO
+    Write-Host "Step 2: Re-enabling Multiplane Overlay (MPO)..." -ForegroundColor Yellow
+
+    try {
+        Remove-ItemProperty -Path $dwmPath -Name "OverlayTestMode" -Force -ErrorAction Stop
+        Write-Host "  Removed OverlayTestMode registry value" -ForegroundColor Green
+        Write-Host "  MPO is now enabled (Windows default)" -ForegroundColor Green
+    } catch {
+        Write-Host "  Failed to remove OverlayTestMode: $($_.Exception.Message)" -ForegroundColor Red
+        if ($TranscriptStarted) { Stop-Transcript }
+        exit 1
+    }
+
+    Write-Host ""
+
+    # Step 3: Verify the setting was removed
+    Write-Host "Step 3: Verifying MPO enable..." -ForegroundColor Yellow
+
+    try {
+        $verifyValue = Get-ItemProperty -Path $dwmPath -Name "OverlayTestMode" -ErrorAction Stop
+        Write-Host "  Warning: OverlayTestMode still exists = $($verifyValue.OverlayTestMode)" -ForegroundColor Yellow
+    } catch {
+        Write-Host "  Verified: OverlayTestMode registry value removed" -ForegroundColor Green
+    }
+
+    Write-Host ""
+
+    # Final summary
+    Write-Host "=== Configuration Summary ===" -ForegroundColor Cyan
+    Write-Host "Multiplane Overlay (MPO): Enabled (Windows default)" -ForegroundColor Green
+    Write-Host "===============================" -ForegroundColor Cyan
+    Write-Host ""
+
+    Write-Host "MPO re-enabled successfully!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Why re-enable MPO:" -ForegroundColor Cyan
+    Write-Host "  - Fixes screen flickering on some older machines" -ForegroundColor White
+    Write-Host "  - Restores Windows default display behavior" -ForegroundColor White
+    Write-Host "  - May improve performance on systems that work well with MPO" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Note: A system restart is required for changes to take effect." -ForegroundColor Yellow
+
+} catch {
+    Write-Error "An error occurred: $($_.Exception.Message)"
+    Write-Host "Error details: $($_.Exception)" -ForegroundColor Red
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}
+
+if ($TranscriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-power-management-config.ps1
+++ b/msft-windows/msft-windows-power-management-config.ps1
@@ -2,19 +2,21 @@
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
 
 # This script configures Windows power management settings:
-# 1. Disables hybrid sleep across all plans
-# 2. Disables fast startup globally
-# 3. Disables hibernation completely  
-# 4. Stops hard disks from turning off on all plans
-# 5. Disables sleeping completely across all plans
-# 6. Allows sleeping only when the lid is shut for laptops across all plans
-# 7. Sets critical battery action to shutdown across all plans
-# 8. Disables USB selective suspend across all plans
-# 9. Disables PCIE Link State Power Management across all plans
-# 10. Enables all wake timers across all plans
-# 11. Sets wireless adapters to maximum performance across all plans
-# 12. Sets video playback to maximum quality across all plans
-# 13. Optimizes multimedia settings for best performance across all plans
+# 1. Sets Balanced power plan as active
+# 2. Disables display timeout (never turn off display)
+# 3. Disables hybrid sleep across all plans
+# 4. Disables fast startup globally
+# 5. Disables hibernation completely
+# 6. Stops hard disks from turning off on all plans
+# 7. Disables sleeping completely across all plans
+# 8. Allows sleeping only when the lid is shut for laptops across all plans
+# 9. Sets critical battery action to shutdown across all plans
+# 10. Disables USB selective suspend across all plans
+# 11. Disables PCIE Link State Power Management across all plans
+# 12. Enables all wake timers across all plans
+# 13. Sets wireless adapters to maximum performance across all plans
+# 14. Sets video playback to maximum quality across all plans
+# 15. Optimizes multimedia settings for best performance across all plans
 
 # Getting input from user if not running from RMM else set variables from RMM.
 
@@ -51,7 +53,13 @@ if ($RMM -ne 1) {
 
 # Start the script logic here.
 
-Start-Transcript -Path $LogPath
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
 
 Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
@@ -68,6 +76,7 @@ try {
     
     if (-not $isAdmin) {
         Write-Error "This script must be run as Administrator to modify power settings."
+        if ($TranscriptStarted) { Stop-Transcript }
         exit 1
     }
     
@@ -90,6 +99,35 @@ try {
     foreach ($scheme in $powerSchemes) {
         $activeIndicator = if ($scheme.IsActive) { " (ACTIVE)" } else { "" }
         Write-Host "  - $($scheme.Name)$activeIndicator" -ForegroundColor Gray
+    }
+    Write-Host ""
+
+    # Step 1b: Set Balanced power plan as active
+    Write-Host "Step 1b: Setting Balanced power plan as active..." -ForegroundColor Yellow
+    try {
+        # Balanced power plan GUID is the same on all Windows installations
+        $balancedGUID = "381b4222-f694-41f0-9685-ff5bb260df2e"
+        powercfg /setactive $balancedGUID
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Balanced power plan activated" -ForegroundColor Green
+        } else {
+            Write-Host "  Could not set Balanced plan (may not exist)" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "  Failed to set Balanced power plan: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+    Write-Host ""
+
+    # Step 1c: Disable display timeout (never turn off display)
+    Write-Host "Step 1c: Disabling display timeout..." -ForegroundColor Yellow
+    try {
+        # Set display timeout to 0 (never) for both AC and DC
+        powercfg /change monitor-timeout-ac 0
+        powercfg /change monitor-timeout-dc 0
+        Write-Host "  Display timeout disabled (AC): Never" -ForegroundColor Green
+        Write-Host "  Display timeout disabled (DC): Never" -ForegroundColor Green
+    } catch {
+        Write-Host "  Failed to disable display timeout: $($_.Exception.Message)" -ForegroundColor Yellow
     }
     Write-Host ""
 
@@ -349,19 +387,21 @@ try {
 
     # Final summary
     Write-Host "=== Configuration Summary ===" -ForegroundColor Cyan
-    Write-Host "✓ Hybrid sleep disabled across all power plans" -ForegroundColor Green
-    Write-Host "✓ Fast startup disabled globally" -ForegroundColor Green
-    Write-Host "✓ Hibernation disabled completely" -ForegroundColor Green
-    Write-Host "✓ Hard disk turn off disabled on all plans" -ForegroundColor Green
-    Write-Host "✓ Automatic sleep disabled across all plans" -ForegroundColor Green
-    Write-Host "✓ Lid close action set to sleep (laptops only)" -ForegroundColor Green
-    Write-Host "✓ Critical battery action set to shutdown" -ForegroundColor Green
-    Write-Host "✓ USB selective suspend disabled for stability" -ForegroundColor Green
-    Write-Host "✓ PCIE Link State Power Management disabled for stability" -ForegroundColor Green
-    Write-Host "✓ Wake timers enabled to allow scheduled tasks" -ForegroundColor Green
-    Write-Host "✓ Wireless adapters set to maximum performance" -ForegroundColor Green
-    Write-Host "✓ Video playback optimized for maximum quality" -ForegroundColor Green
-    Write-Host "✓ Multimedia settings optimized for best performance" -ForegroundColor Green
+    Write-Host "Balanced power plan set as active" -ForegroundColor Green
+    Write-Host "Display timeout disabled (never turn off)" -ForegroundColor Green
+    Write-Host "Hybrid sleep disabled across all power plans" -ForegroundColor Green
+    Write-Host "Fast startup disabled globally" -ForegroundColor Green
+    Write-Host "Hibernation disabled completely" -ForegroundColor Green
+    Write-Host "Hard disk turn off disabled on all plans" -ForegroundColor Green
+    Write-Host "Automatic sleep disabled across all plans" -ForegroundColor Green
+    Write-Host "Lid close action set to sleep (laptops only)" -ForegroundColor Green
+    Write-Host "Critical battery action set to shutdown" -ForegroundColor Green
+    Write-Host "USB selective suspend disabled for stability" -ForegroundColor Green
+    Write-Host "PCIE Link State Power Management disabled for stability" -ForegroundColor Green
+    Write-Host "Wake timers enabled to allow scheduled tasks" -ForegroundColor Green
+    Write-Host "Wireless adapters set to maximum performance" -ForegroundColor Green
+    Write-Host "Video playback optimized for maximum quality" -ForegroundColor Green
+    Write-Host "Multimedia settings optimized for best performance" -ForegroundColor Green
     Write-Host "===============================" -ForegroundColor Cyan
     Write-Host ""
     
@@ -371,7 +411,8 @@ try {
 } catch {
     Write-Error "An error occurred during power management configuration: $($_.Exception.Message)"
     Write-Host "Error details: $($_.Exception)" -ForegroundColor Red
+    if ($TranscriptStarted) { Stop-Transcript }
     exit 1
 }
 
-Stop-Transcript 
+if ($TranscriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-power-management-config.ps1
+++ b/msft-windows/msft-windows-power-management-config.ps1
@@ -102,30 +102,16 @@ try {
     }
     Write-Host ""
 
-    # Step 1b: Set Balanced power plan as active
-    Write-Host "Step 1b: Setting Balanced power plan as active..." -ForegroundColor Yellow
+    # Step 1b: Disable display timeout on ALL power plans (never turn off display)
+    Write-Host "Step 1b: Disabling display timeout on all power plans..." -ForegroundColor Yellow
     try {
-        # Balanced power plan GUID is the same on all Windows installations
-        $balancedGUID = "381b4222-f694-41f0-9685-ff5bb260df2e"
-        powercfg /setactive $balancedGUID
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "  Balanced power plan activated" -ForegroundColor Green
-        } else {
-            Write-Host "  Could not set Balanced plan (may not exist)" -ForegroundColor Yellow
+        # SUB_VIDEO = 7516b95f-f776-4464-8c53-06167f40cc99
+        # VIDEOIDLE (display timeout) = 3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e
+        foreach ($scheme in $powerSchemes) {
+            powercfg /setacvalueindex $($scheme.GUID) 7516b95f-f776-4464-8c53-06167f40cc99 3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e 0 | Out-Null
+            powercfg /setdcvalueindex $($scheme.GUID) 7516b95f-f776-4464-8c53-06167f40cc99 3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e 0 | Out-Null
+            Write-Host "  Display timeout disabled for '$($scheme.Name)'" -ForegroundColor Green
         }
-    } catch {
-        Write-Host "  Failed to set Balanced power plan: $($_.Exception.Message)" -ForegroundColor Yellow
-    }
-    Write-Host ""
-
-    # Step 1c: Disable display timeout (never turn off display)
-    Write-Host "Step 1c: Disabling display timeout..." -ForegroundColor Yellow
-    try {
-        # Set display timeout to 0 (never) for both AC and DC
-        powercfg /change monitor-timeout-ac 0
-        powercfg /change monitor-timeout-dc 0
-        Write-Host "  Display timeout disabled (AC): Never" -ForegroundColor Green
-        Write-Host "  Display timeout disabled (DC): Never" -ForegroundColor Green
     } catch {
         Write-Host "  Failed to disable display timeout: $($_.Exception.Message)" -ForegroundColor Yellow
     }
@@ -222,9 +208,6 @@ try {
              # Critical battery actions: 0=Do nothing, 1=Sleep, 2=Hibernate, 3=Shut down
              # Using actual GUIDs: SUB_BATTERY = E73A048D-BF27-4F12-9731-8B2076E8891F, CRITBATTERYACTION = 637EA02F-BBCB-4015-8E2C-A1C7B9C0B546
              powercfg /setdcvalueindex $($scheme.GUID) E73A048D-BF27-4F12-9731-8B2076E8891F 637EA02F-BBCB-4015-8E2C-A1C7B9C0B546 3 | Out-Null
-            
-            # Apply the settings to the scheme
-            powercfg /setactive $($scheme.GUID) | Out-Null
             
             Write-Host "✓ Power scheme '$($scheme.Name)' configured successfully" -ForegroundColor Green
             
@@ -382,6 +365,22 @@ try {
         } catch {
             Write-Host "Could not retrieve detailed power settings" -ForegroundColor Yellow
         }
+    }
+    Write-Host ""
+
+    # Step 8: Set Balanced power plan as active (do this LAST after all configuration)
+    Write-Host "Step 8: Setting Balanced power plan as active..." -ForegroundColor Yellow
+    try {
+        # Balanced power plan GUID is the same on all Windows installations
+        $balancedGUID = "381b4222-f694-41f0-9685-ff5bb260df2e"
+        powercfg /setactive $balancedGUID
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Balanced power plan activated" -ForegroundColor Green
+        } else {
+            Write-Host "  Could not set Balanced plan (may not exist)" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "  Failed to set Balanced power plan: $($_.Exception.Message)" -ForegroundColor Yellow
     }
     Write-Host ""
 


### PR DESCRIPTION
Start-Transcript can fail silently in certain RMM environments. Added $TranscriptStarted flag to track if transcription is active and only call Stop-Transcript when it was successfully started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scripts to re-enable Multiplane Overlay (MPO) and Core Isolation (Memory Integrity/VBS/hypervisor) with status checks, optional description, logging, and restart guidance.
  * Added a script to re-enable Core Isolation and enhanced power-management configuration with display-timeout and Balanced plan activation.

* **Bug Fixes**
  * Improved transcript/logging handling and error paths to avoid failures when logging cannot start and ensure transcripts are stopped only when active.

* **Other**
  * Clarified disable-flow messaging and hypervisor-related status/output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->