### PR TITLE
Fix CVE-2026-21509 notification and Office closing issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,8 +195,8 @@ function Send-UserNotification {
 
     try {
         # Escape quotes for embedding in script
-        $balloonTitle = $Title -replace '"', '\"'
-        $balloonBody = $Message -replace '"', '\"'
+        $balloonTitle = $Title -replace '"', '`"'
+        $balloonBody = $Message -replace '"', '`"'
 
         # PowerShell script to show balloon notification using Windows Forms
         $balloonScript = @"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,42 +183,36 @@ When a script will perform actions that impact the user (closing applications, r
 
 **User Notification Pattern** (works when running as SYSTEM from RMM):
 
-The standard `msg.exe` command often fails on modern Windows workstations. Use this scheduled task + toast notification pattern instead, which displays a Windows toast notification in the user's session without triggering AV/malware detection:
+The standard `msg.exe` command often fails on modern Windows workstations. Use this scheduled task + balloon notification pattern instead, which displays a system tray balloon tip in the user's session. This method is more reliable than Windows toast notifications and doesn't trigger AV/malware detection like VBScript:
 
 ```powershell
 function Send-UserNotification {
     param(
         [string]$Title,
-        [string]$Message
+        [string]$Message,
+        [int]$DurationSeconds = 30
     )
 
     try {
-        # Escape single quotes for embedding in script
-        $toastTitle = $Title -replace "'", "''"
-        $toastBody = $Message -replace "'", "''"
+        # Escape quotes for embedding in script
+        $balloonTitle = $Title -replace '"', '\"'
+        $balloonBody = $Message -replace '"', '\"'
 
-        # Build toast notification PowerShell script (no external files needed)
-        $toastScript = @"
-`$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]
-`$null = [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime]
-`$toastXml = @'
-<toast duration="long" scenario="urgent">
-    <visual>
-        <binding template="ToastGeneric">
-            <text>$toastTitle</text>
-            <text>$toastBody</text>
-        </binding>
-    </visual>
-    <audio src="ms-winsoundevent:Notification.Looping.Alarm2" loop="false"/>
-</toast>
-'@
-`$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
-`$xml.LoadXml(`$toastXml)
-`$toast = New-Object Windows.UI.Notifications.ToastNotification `$xml
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Microsoft.Windows.Shell.RunDialog').Show(`$toast)
+        # PowerShell script to show balloon notification using Windows Forms
+        $balloonScript = @"
+Add-Type -AssemblyName System.Windows.Forms
+`$balloon = New-Object System.Windows.Forms.NotifyIcon
+`$balloon.Icon = [System.Drawing.SystemIcons]::Warning
+`$balloon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Warning
+`$balloon.BalloonTipTitle = "$balloonTitle"
+`$balloon.BalloonTipText = "$balloonBody"
+`$balloon.Visible = `$true
+`$balloon.ShowBalloonTip($($DurationSeconds * 1000))
+Start-Sleep -Seconds $DurationSeconds
+`$balloon.Dispose()
 "@
         # Encode the script for safe execution
-        $encodedScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($toastScript))
+        $encodedScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($balloonScript))
 
         # Create scheduled task to run in user context (works when script runs as SYSTEM)
         $taskName = "UserNotification_$(Get-Random)"
@@ -241,10 +235,11 @@ function Send-UserNotification {
 ```
 
 **Key Points**:
+- Uses `System.Windows.Forms.NotifyIcon` - a reliable, mature API that works consistently
 - No external files created (avoids AV/malware detection that VBS triggers)
-- Uses Windows 10/11 native toast notification API via encoded PowerShell command
+- Runs via scheduled task in user context (works when main script runs as SYSTEM)
 - Scheduled task auto-deletes after 30 minutes via trigger EndBoundary
-- Uses `scenario="urgent"` for high-priority notification appearance
+- Balloon tip shows in system tray with warning icon
 - Always include a configurable delay (`$NotificationDelaySeconds`) before the impactful action
 
 **Example Usage**:

--- a/msft-office/cve-2026-21509-remediate.ps1
+++ b/msft-office/cve-2026-21509-remediate.ps1
@@ -200,55 +200,44 @@ $contactInfo
 
     $messageSent = $false
 
-    # Method 1: Toast notification via scheduled task (works when running as SYSTEM)
+    # Method 1: Balloon notification via scheduled task (reliable, works when running as SYSTEM)
     try {
         $explorerProcesses = Get-Process -Name explorer -ErrorAction SilentlyContinue
         if ($explorerProcesses) {
-            # Build toast notification PowerShell script (no external files needed)
-            $toastTitle = $title -replace "'", "''"
-            $toastBody = "Office will close in $delayMinutes minute(s) for security update (CVE-2026-21509). SAVE YOUR WORK NOW!" -replace "'", "''"
+            $balloonTitle = $title -replace '"', '\"'
+            $balloonBody = "Office will close in $delayMinutes minute(s) for security update. SAVE YOUR WORK NOW!" -replace '"', '\"'
 
-            $toastScript = @"
-`$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]
-`$null = [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime]
-`$toastXml = @'
-<toast duration="long" scenario="urgent">
-    <visual>
-        <binding template="ToastGeneric">
-            <text>$toastTitle</text>
-            <text>$toastBody</text>
-        </binding>
-    </visual>
-    <audio src="ms-winsoundevent:Notification.Looping.Alarm2" loop="false"/>
-</toast>
-'@
-`$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
-`$xml.LoadXml(`$toastXml)
-`$toast = New-Object Windows.UI.Notifications.ToastNotification `$xml
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Microsoft.Windows.Shell.RunDialog').Show(`$toast)
+            # PowerShell script to show balloon notification using Windows Forms
+            $balloonScript = @"
+Add-Type -AssemblyName System.Windows.Forms
+`$balloon = New-Object System.Windows.Forms.NotifyIcon
+`$balloon.Icon = [System.Drawing.SystemIcons]::Warning
+`$balloon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Warning
+`$balloon.BalloonTipTitle = "$balloonTitle"
+`$balloon.BalloonTipText = "$balloonBody"
+`$balloon.Visible = `$true
+`$balloon.ShowBalloonTip(30000)
+Start-Sleep -Seconds 30
+`$balloon.Dispose()
 "@
-            # Encode the script for safe execution
-            $encodedScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($toastScript))
+            $encodedScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($balloonScript))
 
-            # Create a scheduled task to run as the logged-in user
+            # Create scheduled task to run in user context
             $taskName = "OfficeSecurityWarning_$(Get-Random)"
             $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -WindowStyle Hidden -EncodedCommand $encodedScript"
-            $principal = New-ScheduledTaskPrincipal -GroupId "S-1-5-32-545" -RunLevel Limited  # Users group
-            # Create one-time trigger with end boundary for auto-deletion
+            $principal = New-ScheduledTaskPrincipal -GroupId "S-1-5-32-545" -RunLevel Limited
             $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date)
             $trigger.EndBoundary = (Get-Date).AddMinutes(30).ToString("yyyy-MM-ddTHH:mm:ss")
-            # Task auto-deletes after expiration
             $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -DeleteExpiredTaskAfter 00:00:01
 
-            $task = Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Trigger $trigger -Settings $settings -Force
-
+            Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Trigger $trigger -Settings $settings -Force | Out-Null
             Start-ScheduledTask -TaskName $taskName
 
-            Write-Host "  [SUCCESS] User warning displayed via toast notification"
+            Write-Host "  [SUCCESS] User warning displayed via balloon notification"
             $messageSent = $true
         }
     } catch {
-        Write-Host "  [INFO] Toast notification method failed: $_"
+        Write-Host "  [INFO] Balloon notification method failed: $_"
     }
 
     # Method 2: Fallback to msg.exe (works in some environments)
@@ -773,33 +762,35 @@ if ($c2rInfo.Installed) {
     Write-Host ""
 }
 
+# Step 1: Close Office applications if requested (runs regardless of ApplyUpdates setting)
+$officesClosed = $true
+if ($ForceCloseOffice -eq 1) {
+    Write-Host "============================================"
+    Write-Host "CLOSING OFFICE APPLICATIONS"
+    Write-Host "============================================"
+    Write-Host ""
+
+    $runningProcs = Get-RunningOfficeProcesses
+
+    if ($runningProcs.Count -gt 0) {
+        $officesClosed = Close-OfficeApplications -Force -DelaySeconds $CloseOfficeDelaySeconds -SupportPhone $SupportPhone -SupportEmail $SupportEmail
+        if ($officesClosed) {
+            $actionsPerformed += "Closed running Office applications (with $CloseOfficeDelaySeconds second warning)"
+        } else {
+            $actionsFailed += "Close Office applications"
+        }
+    } else {
+        Write-Host "[INFO] No Office applications currently running"
+    }
+    Write-Host ""
+}
+
 # Handle updates if enabled
 if ($ApplyUpdates -eq 1) {
     Write-Host "============================================"
     Write-Host "OFFICE UPDATE PROCESS"
     Write-Host "============================================"
     Write-Host ""
-
-    # Step 1: Close Office applications if needed/requested
-    $officesClosed = $true
-    $runningProcs = Get-RunningOfficeProcesses
-
-    if ($runningProcs.Count -gt 0) {
-        if ($ForceCloseOffice -eq 1) {
-            $officesClosed = Close-OfficeApplications -Force -DelaySeconds $CloseOfficeDelaySeconds -SupportPhone $SupportPhone -SupportEmail $SupportEmail
-            if ($officesClosed) {
-                $actionsPerformed += "Closed running Office applications (with $CloseOfficeDelaySeconds second warning)"
-            } else {
-                $actionsFailed += "Close Office applications"
-            }
-        } else {
-            Write-Host "[WARNING] Office applications are running. Updates may not apply fully."
-            Write-Host "[INFO] Set ForceCloseOffice=1 to automatically close Office apps"
-            $actionsSkipped += "Close Office applications (ForceCloseOffice not enabled)"
-            $officesClosed = $false
-        }
-        Write-Host ""
-    }
 
     # Step 2: Attempt updates based on installation type and method preference
     Write-Host "[INFO] Attempting Office update (Method: $UpdateMethod)..."

--- a/msft-office/cve-2026-21509-remediate.ps1
+++ b/msft-office/cve-2026-21509-remediate.ps1
@@ -204,8 +204,8 @@ $contactInfo
     try {
         $explorerProcesses = Get-Process -Name explorer -ErrorAction SilentlyContinue
         if ($explorerProcesses) {
-            $balloonTitle = $title -replace '"', '\"'
-            $balloonBody = "Office will close in $delayMinutes minute(s) for security update. SAVE YOUR WORK NOW!" -replace '"', '\"'
+            $balloonTitle = $title -replace '"', '`"'
+            $balloonBody = "Office will close in $delayMinutes minute(s) for security update. SAVE YOUR WORK NOW!" -replace '"', '`"'
 
             # PowerShell script to show balloon notification using Windows Forms
             $balloonScript = @"


### PR DESCRIPTION
- Replace unreliable toast notification with balloon notification (System.Windows.Forms.NotifyIcon) - more reliable API
- Move Office close logic outside ApplyUpdates block so it runs when ForceCloseOffice=1 regardless of update settings
- Update CLAUDE.md with balloon notification pattern

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System tray balloon notifications replace toast notifications for user alerts.
  * Notification display duration is configurable (default: 30 seconds).

* **Improvements**
  * Remediation workflow reorganized into clearer step-by-step stages with improved progress messaging.
  * Office-app closing and update flows simplified for more consistent behavior and reporting.
  * Notification fallback strategy and success/failure messaging made more reliable and informative.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->