### PR TITLE
Add weekly orphaned installer patch monitor for NinjaRMM

### DIFF
--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -1,0 +1,287 @@
+<#
+.SYNOPSIS
+    DTC Installer Patch Monitor — Weekly scan of C:\Windows\Installer for orphaned .msi/.msp files.
+.DESCRIPTION
+    Scans C:\Windows\Installer to identify orphaned installer cache files by querying the
+    Windows Installer registry database. Reports results to NinjaRMM custom fields and
+    Windows Event Log. Makes ZERO filesystem changes — read-only analysis only.
+
+    Deployment: NinjaRMM scheduled script, run weekly (e.g., Sunday 2:00 AM).
+    Runs as: SYSTEM
+
+    Reference: HALO Ticket 1125653 — 128 GB orphaned patches, 96.1% disk utilization.
+.NOTES
+    Author:  DTC Engineering
+    Version: 1.0.0
+    Requires: PowerShell 5.1, Windows 10/11/Server 2019/2022
+    Dependencies: None (self-contained)
+#>
+
+#Requires -Version 5.1
+
+# ============================================================================
+# CONFIGURATION — Adjust thresholds here
+# ============================================================================
+$WarningThresholdGB  = 20   # Total Installer folder size >= this = "Warning"
+$CriticalThresholdGB = 50   # Total Installer folder size >= this = "Critical"
+
+# ============================================================================
+# SHARED FUNCTION: Get-OrphanedInstallerFiles
+# ============================================================================
+function Get-OrphanedInstallerFiles {
+    <#
+    .SYNOPSIS
+        Identifies orphaned .msi and .msp files in C:\Windows\Installer by querying
+        the Windows Installer registry database.
+    .DESCRIPTION
+        Enumerates the Windows Installer registry database to build a set of "referenced"
+        installer files (files that belong to currently installed products/patches).
+        Any .msi/.msp file in C:\Windows\Installer that is NOT in the referenced set
+        is classified as orphaned.
+
+        Does NOT use Win32_Product WMI class (triggers MSI reconfigure/consistency check).
+        Uses registry queries only.
+    .OUTPUTS
+        PSCustomObject with properties:
+        - TotalFiles (int)
+        - TotalSizeBytes (long)
+        - ReferencedFiles (array of PSCustomObject: FullPath, SizeBytes)
+        - ReferencedCount (int)
+        - ReferencedSizeBytes (long)
+        - OrphanedFiles (array of PSCustomObject: FullPath, SizeBytes, LastWriteTime)
+        - OrphanedCount (int)
+        - OrphanedSizeBytes (long)
+        - PatchCacheSizeBytes (long)
+        - ScanDuration (timespan)
+        - Errors (array of strings)
+    #>
+    [CmdletBinding()]
+    param()
+
+    $startTime = Get-Date
+    $errors = @()
+
+    # --- STEP 1: Build the "referenced files" set ---
+    # The Windows Installer stores product/patch cache file references in the registry.
+    # Products: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\{GUID}\InstallProperties
+    #   → "LocalPackage" value = path to cached .msi file
+    # Patches: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Patches\{GUID}
+    #   → "LocalPackage" value = path to cached .msp file
+    #
+    # NOTE: Registry GUIDs are in "compressed" format (no dashes, no braces, character reordering).
+    # However, the LocalPackage values contain standard file paths — we do NOT need to decompress
+    # GUIDs. We just collect the LocalPackage values directly.
+
+    $referencedFiles = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+
+    # Collect referenced MSI files from Products
+    $productsPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products"
+    try {
+        if (Test-Path $productsPath) {
+            $productGuids = Get-ChildItem $productsPath -ErrorAction Stop
+            foreach ($product in $productGuids) {
+                try {
+                    $installProps = Join-Path $product.PSPath "InstallProperties"
+                    if (Test-Path $installProps) {
+                        $localPackage = (Get-ItemProperty $installProps -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
+                        if ($localPackage -and (Test-Path $localPackage)) {
+                            [void]$referencedFiles.Add($localPackage)
+                        }
+                    }
+                } catch {
+                    $errors += "Product $($product.PSChildName): $($_.Exception.Message)"
+                }
+            }
+        }
+    } catch {
+        # If we can't read the Products key at all, this is a critical failure
+        throw "Failed to read Products registry path: $($_.Exception.Message)"
+    }
+
+    # Collect referenced MSP files from Patches
+    $patchesPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Patches"
+    try {
+        if (Test-Path $patchesPath) {
+            $patchGuids = Get-ChildItem $patchesPath -ErrorAction Stop
+            foreach ($patch in $patchGuids) {
+                try {
+                    $localPackage = (Get-ItemProperty $patch.PSPath -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
+                    if ($localPackage -and (Test-Path $localPackage)) {
+                        [void]$referencedFiles.Add($localPackage)
+                    }
+                } catch {
+                    $errors += "Patch $($patch.PSChildName): $($_.Exception.Message)"
+                }
+            }
+        }
+    } catch {
+        throw "Failed to read Patches registry path: $($_.Exception.Message)"
+    }
+
+    # --- STEP 2: Enumerate actual files in C:\Windows\Installer ---
+    # Top-level only — do NOT include $PatchCache$ subfolder contents
+    $installerPath = "C:\Windows\Installer"
+    $allFiles = Get-ChildItem $installerPath -File -Force -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -in '.msi', '.msp' }
+
+    # --- STEP 3: Compare and classify ---
+    $referenced = @()
+    $orphaned = @()
+
+    foreach ($file in $allFiles) {
+        if ($referencedFiles.Contains($file.FullName)) {
+            $referenced += [PSCustomObject]@{
+                FullPath  = $file.FullName
+                SizeBytes = $file.Length
+            }
+        } else {
+            $orphaned += [PSCustomObject]@{
+                FullPath      = $file.FullName
+                SizeBytes     = $file.Length
+                LastWriteTime = $file.LastWriteTime
+            }
+        }
+    }
+
+    # --- STEP 4: Measure $PatchCache$ separately ---
+    $patchCachePath = Join-Path $installerPath '$PatchCache$'
+    $patchCacheSize = 0
+    if (Test-Path $patchCachePath) {
+        $patchCacheSize = (Get-ChildItem $patchCachePath -Recurse -Force -ErrorAction SilentlyContinue |
+            Measure-Object Length -Sum).Sum
+    }
+
+    # --- STEP 5: Return results ---
+    [PSCustomObject]@{
+        TotalFiles          = ($allFiles | Measure-Object).Count
+        TotalSizeBytes      = ($allFiles | Measure-Object Length -Sum).Sum
+        ReferencedFiles     = $referenced
+        ReferencedCount     = $referenced.Count
+        ReferencedSizeBytes = ($referenced | Measure-Object SizeBytes -Sum).Sum
+        OrphanedFiles       = $orphaned
+        OrphanedCount       = $orphaned.Count
+        OrphanedSizeBytes   = ($orphaned | Measure-Object SizeBytes -Sum).Sum
+        PatchCacheSizeBytes = $patchCacheSize
+        ScanDuration        = (Get-Date) - $startTime
+        Errors              = $errors
+    }
+}
+
+# ============================================================================
+# MAIN EXECUTION
+# ============================================================================
+Write-Output "DTC Installer Patch Monitor — Starting scan..."
+Write-Output "Timestamp: $(Get-Date -Format 'o')"
+Write-Output ""
+
+$status = "Healthy"
+$totalSizeGB = 0
+$orphanedSizeGB = 0
+$orphanedCount = 0
+$referencedCount = 0
+$referencedSizeGB = 0
+$patchCacheSizeGB = 0
+$winsxsSizeGB = 0
+$scanErrors = @()
+
+try {
+    # --- Run orphan detection ---
+    $results = Get-OrphanedInstallerFiles
+
+    $totalSizeGB     = [math]::Round($results.TotalSizeBytes / 1GB, 2)
+    $orphanedSizeGB  = [math]::Round($results.OrphanedSizeBytes / 1GB, 2)
+    $orphanedCount   = $results.OrphanedCount
+    $referencedCount = $results.ReferencedCount
+    $referencedSizeGB = [math]::Round($results.ReferencedSizeBytes / 1GB, 2)
+    $patchCacheSizeGB = [math]::Round($results.PatchCacheSizeBytes / 1GB, 2)
+    $scanErrors      = $results.Errors
+
+    # --- Measure WinSxS size (secondary indicator) ---
+    $winsxsSize = (Get-ChildItem "C:\Windows\WinSxS" -Recurse -Force -ErrorAction SilentlyContinue |
+        Measure-Object Length -Sum).Sum
+    $winsxsSizeGB = [math]::Round($winsxsSize / 1GB, 2)
+
+    # --- Determine status based on total Installer folder size ---
+    if ($totalSizeGB -gt $CriticalThresholdGB) {
+        $status = "Critical"
+    } elseif ($totalSizeGB -gt $WarningThresholdGB) {
+        $status = "Warning"
+    } else {
+        $status = "Healthy"
+    }
+} catch {
+    $status = "Error"
+    $scanErrors += "Critical scan failure: $($_.Exception.Message)"
+    Write-Error "Scan failed: $($_.Exception.Message)"
+}
+
+# ============================================================================
+# WRITE NINJARMM CUSTOM FIELDS
+# ============================================================================
+try {
+    Ninja-Property-Set installerFolderSizeGB ([math]::Round($totalSizeGB, 2))
+    Ninja-Property-Set installerOrphanedSizeGB ([math]::Round($orphanedSizeGB, 2))
+    Ninja-Property-Set installerOrphanedCount $orphanedCount
+    Ninja-Property-Set installerWinSxSSizeGB ([math]::Round($winsxsSizeGB, 2))
+    Ninja-Property-Set installerStatus $status
+    Ninja-Property-Set installerLastScan (Get-Date -Format "o")
+} catch {
+    # Ninja-Property-Set not available (running outside NinjaRMM) — log locally
+    Write-Warning "NinjaRMM custom field write failed: $($_.Exception.Message)"
+}
+
+# ============================================================================
+# WRITE WINDOWS EVENT LOG
+# ============================================================================
+$source = "DTC-InstallerMonitor"
+$logName = "Application"
+if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+    try {
+        [System.Diagnostics.EventLog]::CreateEventSource($source, $logName)
+    } catch {
+        # May fail without admin — continue anyway
+    }
+}
+
+$eventId = switch ($status) {
+    "Healthy"  { 1000 }
+    "Warning"  { 2000 }
+    "Critical" { 2000 }
+    "Error"    { 3000 }
+}
+$message = @"
+DTC Installer Patch Monitor — Scan Complete
+Status: $status
+Total Installer Folder: $totalSizeGB GB
+Orphaned Files: $orphanedCount ($orphanedSizeGB GB)
+Referenced Files: $referencedCount ($referencedSizeGB GB)
+PatchCache: $patchCacheSizeGB GB
+WinSxS: $winsxsSizeGB GB
+Scan Duration: $($results.ScanDuration.TotalSeconds) seconds
+"@
+if ($scanErrors.Count -gt 0) {
+    $message += "`nErrors:`n" + ($scanErrors -join "`n")
+}
+try {
+    Write-EventLog -LogName $logName -Source $source -EventId $eventId -EntryType Information -Message $message
+} catch {
+    Write-Warning "Event log write failed: $($_.Exception.Message)"
+}
+
+# ============================================================================
+# CONSOLE SUMMARY (appears in NinjaRMM script log)
+# ============================================================================
+Write-Output "=== SCAN RESULTS ==="
+Write-Output "Status:             $status"
+Write-Output "Installer Folder:   $totalSizeGB GB ($($results.TotalFiles) files)"
+Write-Output "  Referenced:       $referencedSizeGB GB ($referencedCount files)"
+Write-Output "  Orphaned:         $orphanedSizeGB GB ($orphanedCount files)"
+Write-Output "  PatchCache:       $patchCacheSizeGB GB"
+Write-Output "WinSxS:             $winsxsSizeGB GB"
+Write-Output "Scan Duration:      $($results.ScanDuration.TotalSeconds) seconds"
+if ($scanErrors.Count -gt 0) {
+    Write-Output ""
+    Write-Output "Non-critical errors ($($scanErrors.Count)):"
+    $scanErrors | ForEach-Object { Write-Output "  - $_" }
+}
+Write-Output "===================="

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -43,8 +43,9 @@ function Get-OrphanedInstallerFiles {
         Uses registry queries only.
     .OUTPUTS
         PSCustomObject with properties:
-        - TotalFiles (int)
-        - TotalSizeBytes (long)
+        - InstallerFolderTotalBytes (long) — unfiltered folder total (all file types)
+        - TotalFiles (int) — MSI/MSP files only
+        - TotalSizeBytes (long) — MSI/MSP files only
         - ReferencedFiles (array of PSCustomObject: FullPath, SizeBytes)
         - ReferencedCount (int)
         - ReferencedSizeBytes (long)
@@ -59,7 +60,7 @@ function Get-OrphanedInstallerFiles {
     param()
 
     $startTime = Get-Date
-    $errors = @()
+    $registryErrors = @()
 
     # --- STEP 1: Build the "referenced files" set ---
     # The Windows Installer stores product/patch cache file references in the registry.
@@ -89,7 +90,7 @@ function Get-OrphanedInstallerFiles {
                         }
                     }
                 } catch {
-                    $errors += "Product $($product.PSChildName): $($_.Exception.Message)"
+                    $registryErrors += "Product $($product.PSChildName): $($_.Exception.Message)"
                 }
             }
         }
@@ -110,7 +111,7 @@ function Get-OrphanedInstallerFiles {
                         [void]$referencedFiles.Add($localPackage)
                     }
                 } catch {
-                    $errors += "Patch $($patch.PSChildName): $($_.Exception.Message)"
+                    $registryErrors += "Patch $($patch.PSChildName): $($_.Exception.Message)"
                 }
             }
         }
@@ -121,25 +122,28 @@ function Get-OrphanedInstallerFiles {
     # --- STEP 2: Enumerate actual files in C:\Windows\Installer ---
     # Top-level only — do NOT include $PatchCache$ subfolder contents
     $installerPath = "C:\Windows\Installer"
-    $allFiles = Get-ChildItem $installerPath -File -Force -ErrorAction SilentlyContinue |
-        Where-Object { $_.Extension -in '.msi', '.msp' }
+    # Enumerate all files first (unfiltered) for accurate folder-total metric, then filter for orphan detection.
+    # This avoids misleading operators when comparing script output against Explorer-reported folder sizes.
+    $allInstallerFiles = Get-ChildItem $installerPath -File -Force -ErrorAction SilentlyContinue
+    $allFiles = $allInstallerFiles | Where-Object { $_.Extension -in '.msi', '.msp' }
 
     # --- STEP 3: Compare and classify ---
-    $referenced = @()
-    $orphaned = @()
+    # Use List<T> instead of @() += to avoid O(n^2) array reallocation on machines with thousands of files
+    $referenced = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $orphaned   = [System.Collections.Generic.List[PSCustomObject]]::new()
 
     foreach ($file in $allFiles) {
         if ($referencedFiles.Contains($file.FullName)) {
-            $referenced += [PSCustomObject]@{
+            $referenced.Add([PSCustomObject]@{
                 FullPath  = $file.FullName
                 SizeBytes = $file.Length
-            }
+            })
         } else {
-            $orphaned += [PSCustomObject]@{
+            $orphaned.Add([PSCustomObject]@{
                 FullPath      = $file.FullName
                 SizeBytes     = $file.Length
                 LastWriteTime = $file.LastWriteTime
-            }
+            })
         }
     }
 
@@ -153,19 +157,22 @@ function Get-OrphanedInstallerFiles {
     }
 
     # --- STEP 5: Return results ---
-    # Null-coerce all Measure-Object .Sum results — .Sum returns $null on empty collections
+    # Null-coerce all Measure-Object .Sum results — .Sum returns $null on empty collections.
+    # InstallerFolderTotalBytes = unfiltered folder total (matches Explorer-reported size).
+    # TotalFiles/TotalSizeBytes = MSI/MSP-only subset used for orphan detection.
     [PSCustomObject]@{
-        TotalFiles          = ($allFiles | Measure-Object).Count -as [int]
-        TotalSizeBytes      = ($allFiles | Measure-Object Length -Sum).Sum -as [long]
-        ReferencedFiles     = $referenced
-        ReferencedCount     = $referenced.Count
-        ReferencedSizeBytes = ($referenced | Measure-Object SizeBytes -Sum).Sum -as [long]
-        OrphanedFiles       = $orphaned
-        OrphanedCount       = $orphaned.Count
-        OrphanedSizeBytes   = ($orphaned | Measure-Object SizeBytes -Sum).Sum -as [long]
-        PatchCacheSizeBytes = $patchCacheSize
-        ScanDuration        = (Get-Date) - $startTime
-        Errors              = $errors
+        InstallerFolderTotalBytes = ($allInstallerFiles | Measure-Object Length -Sum).Sum -as [long]
+        TotalFiles                = ($allFiles | Measure-Object).Count -as [int]
+        TotalSizeBytes            = ($allFiles | Measure-Object Length -Sum).Sum -as [long]
+        ReferencedFiles           = $referenced
+        ReferencedCount           = $referenced.Count
+        ReferencedSizeBytes       = ($referenced | Measure-Object SizeBytes -Sum).Sum -as [long]
+        OrphanedFiles             = $orphaned
+        OrphanedCount             = $orphaned.Count
+        OrphanedSizeBytes         = ($orphaned | Measure-Object SizeBytes -Sum).Sum -as [long]
+        PatchCacheSizeBytes       = $patchCacheSize
+        ScanDuration              = (Get-Date) - $startTime
+        Errors                    = $registryErrors
     }
 }
 
@@ -177,6 +184,7 @@ Write-Output "Timestamp: $(Get-Date -Format 'o')"
 Write-Output ""
 
 $status = "Healthy"
+$installerFolderSizeGB = 0
 $totalSizeGB = 0
 $orphanedSizeGB = 0
 $orphanedCount = 0
@@ -192,6 +200,9 @@ try {
     # --- Run orphan detection ---
     $results = Get-OrphanedInstallerFiles
 
+    # InstallerFolderTotalBytes = unfiltered folder total (all file types, matches Explorer)
+    # TotalSizeBytes = MSI/MSP-only subset (what orphan detection covers)
+    $installerFolderSizeGB = [math]::Round($results.InstallerFolderTotalBytes / 1GB, 2)
     $totalSizeGB      = [math]::Round($results.TotalSizeBytes / 1GB, 2)
     $orphanedSizeGB   = [math]::Round($results.OrphanedSizeBytes / 1GB, 2)
     $orphanedCount    = $results.OrphanedCount
@@ -203,19 +214,26 @@ try {
     $scanErrors       = $results.Errors
 
     # --- Measure WinSxS size (secondary indicator) ---
-    # NOTE: WinSxS uses hardlinks extensively. Recursive enumeration overcounts actual disk
-    # footprint by 2-3x because the same physical data is counted per hardlink. This value
-    # is a rough indicator, not an exact measurement. Use DISM /AnalyzeComponentStore for
-    # precise sizing if needed.
-    $winsxsSize = (Get-ChildItem "C:\Windows\WinSxS" -Recurse -Force -ErrorAction SilentlyContinue |
-        Measure-Object Length -Sum).Sum -as [long]
-    if (-not $winsxsSize) { $winsxsSize = [long]0 }
+    # NOTE: WinSxS uses hardlinks extensively — enumeration overcounts actual disk footprint
+    # by 2-3x. This is a rough indicator only. Use DISM /AnalyzeComponentStore for precise sizing.
+    # Uses .NET EnumerateFiles (lazy iterator) instead of Get-ChildItem -Recurse to avoid
+    # blocking the script for 2-10+ minutes on HDD-backed or heavily-loaded servers.
+    try {
+        $winsxsSize = [long]0
+        foreach ($f in [System.IO.Directory]::EnumerateFiles("C:\Windows\WinSxS", "*", [System.IO.SearchOption]::AllDirectories)) {
+            try { $winsxsSize += ([System.IO.FileInfo]::new($f)).Length } catch { }
+        }
+    } catch {
+        $winsxsSize = [long]0
+    }
     $winsxsSizeGB = [math]::Round($winsxsSize / 1GB, 2)
 
     # --- Determine status based on total Installer folder size ---
-    if ($totalSizeGB -ge $CriticalThresholdGB) {
+    # Uses the unfiltered folder total (InstallerFolderTotalBytes) for threshold comparison
+    # so status matches what operators see in Explorer
+    if ($installerFolderSizeGB -ge $CriticalThresholdGB) {
         $status = "Critical"
-    } elseif ($totalSizeGB -ge $WarningThresholdGB) {
+    } elseif ($installerFolderSizeGB -ge $WarningThresholdGB) {
         $status = "Warning"
     } else {
         $status = "Healthy"
@@ -230,10 +248,10 @@ try {
 # WRITE NINJARMM CUSTOM FIELDS
 # ============================================================================
 try {
-    Ninja-Property-Set installerFolderSizeGB ([math]::Round($totalSizeGB, 2))
-    Ninja-Property-Set installerOrphanedSizeGB ([math]::Round($orphanedSizeGB, 2))
+    Ninja-Property-Set installerFolderSizeGB $installerFolderSizeGB
+    Ninja-Property-Set installerOrphanedSizeGB $orphanedSizeGB
     Ninja-Property-Set installerOrphanedCount $orphanedCount
-    Ninja-Property-Set installerWinSxSSizeGB ([math]::Round($winsxsSizeGB, 2))
+    Ninja-Property-Set installerWinSxSSizeGB $winsxsSizeGB
     Ninja-Property-Set installerStatus $status
     Ninja-Property-Set installerLastScan (Get-Date -Format "o")
 } catch {
@@ -263,6 +281,7 @@ $eventId = switch ($status) {
     "Warning"  { 2000 }
     "Critical" { 2500 }
     "Error"    { 3000 }
+    default    { 3000 }
 }
 # Map EntryType to actual severity so SIEM/monitoring tools can filter
 $entryType = switch ($status) {
@@ -270,11 +289,13 @@ $entryType = switch ($status) {
     "Warning"  { "Warning" }
     "Critical" { "Error" }
     "Error"    { "Error" }
+    default    { "Error" }
 }
 $message = @"
 DTC Installer Patch Monitor — Scan Complete
 Status: $status
-Total Installer Folder: $totalSizeGB GB
+Installer Folder Total: $installerFolderSizeGB GB
+MSI/MSP Files: $totalFiles ($totalSizeGB GB)
 Orphaned Files: $orphanedCount ($orphanedSizeGB GB)
 Referenced Files: $referencedCount ($referencedSizeGB GB)
 PatchCache: $patchCacheSizeGB GB
@@ -295,9 +316,10 @@ try {
 # ============================================================================
 Write-Output "=== SCAN RESULTS ==="
 Write-Output "Status:             $status"
-Write-Output "Installer Folder:   $totalSizeGB GB ($totalFiles files)"
-Write-Output "  Referenced:       $referencedSizeGB GB ($referencedCount files)"
-Write-Output "  Orphaned:         $orphanedSizeGB GB ($orphanedCount files)"
+Write-Output "Installer Folder:   $installerFolderSizeGB GB"
+Write-Output "  MSI/MSP Files:    $totalSizeGB GB ($totalFiles files)"
+Write-Output "    Referenced:     $referencedSizeGB GB ($referencedCount files)"
+Write-Output "    Orphaned:       $orphanedSizeGB GB ($orphanedCount files)"
 Write-Output "  PatchCache:       $patchCacheSizeGB GB"
 Write-Output "WinSxS:             $winsxsSizeGB GB (approximate — hardlink overcount)"
 Write-Output "Scan Duration:      $scanDurationSec seconds"

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -43,7 +43,7 @@ function Get-OrphanedInstallerFiles {
         Uses registry queries only.
     .OUTPUTS
         PSCustomObject with properties:
-        - InstallerFolderTotalBytes (long) — unfiltered folder total (all file types)
+        - InstallerFolderTotalBytes (long) — folder total incl. $PatchCache$ (matches Explorer)
         - TotalFiles (int) — MSI/MSP files only
         - TotalSizeBytes (long) — MSI/MSP files only
         - ReferencedFiles (array of PSCustomObject: FullPath, SizeBytes)
@@ -121,7 +121,7 @@ function Get-OrphanedInstallerFiles {
 
     # --- STEP 2: Enumerate actual files in C:\Windows\Installer ---
     # Top-level only — do NOT include $PatchCache$ subfolder contents
-    $installerPath = "C:\Windows\Installer"
+    $installerPath = Join-Path $env:SystemRoot "Installer"
     # Enumerate all files first (unfiltered) for accurate folder-total metric, then filter for orphan detection.
     # This avoids misleading operators when comparing script output against Explorer-reported folder sizes.
     $allInstallerFiles = Get-ChildItem $installerPath -File -Force -ErrorAction SilentlyContinue
@@ -158,10 +158,11 @@ function Get-OrphanedInstallerFiles {
 
     # --- STEP 5: Return results ---
     # Null-coerce all Measure-Object .Sum results — .Sum returns $null on empty collections.
-    # InstallerFolderTotalBytes = unfiltered folder total (matches Explorer-reported size).
+    # InstallerFolderTotalBytes = top-level files + $PatchCache$ (matches Explorer-reported size).
     # TotalFiles/TotalSizeBytes = MSI/MSP-only subset used for orphan detection.
+    $topLevelTotal = ($allInstallerFiles | Measure-Object Length -Sum).Sum -as [long]
     [PSCustomObject]@{
-        InstallerFolderTotalBytes = ($allInstallerFiles | Measure-Object Length -Sum).Sum -as [long]
+        InstallerFolderTotalBytes = $topLevelTotal + $patchCacheSize
         TotalFiles                = ($allFiles | Measure-Object).Count -as [int]
         TotalSizeBytes            = ($allFiles | Measure-Object Length -Sum).Sum -as [long]
         ReferencedFiles           = $referenced
@@ -220,7 +221,8 @@ try {
     # blocking the script for 2-10+ minutes on HDD-backed or heavily-loaded servers.
     try {
         $winsxsSize = [long]0
-        foreach ($f in [System.IO.Directory]::EnumerateFiles("C:\Windows\WinSxS", "*", [System.IO.SearchOption]::AllDirectories)) {
+        $winsxsPath = Join-Path $env:SystemRoot "WinSxS"
+        foreach ($f in [System.IO.Directory]::EnumerateFiles($winsxsPath, "*", [System.IO.SearchOption]::AllDirectories)) {
             try { $winsxsSize += ([System.IO.FileInfo]::new($f)).Length } catch { }
         }
     } catch {

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -283,7 +283,12 @@ try {
     Write-Warning "Event source registration skipped: $($_.Exception.Message)"
 }
 
-# Distinct Event IDs per severity for monitoring tool granularity
+# Distinct Event IDs per severity — intentionally separated so SIEM rules can
+# target each level independently:
+#   Healthy  = 1000 (Information)
+#   Warning  = 2000 (Warning)
+#   Critical = 2500 (Error)
+#   Error    = 3000 (Error)
 $eventId = switch ($status) {
     "Healthy"  { 1000 }
     "Warning"  { 2000 }

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -69,6 +69,8 @@ function Get-OrphanedInstallerFiles {
     # reference files in C:\Windows\Installer. Missing per-user SIDs inflates orphan counts.
     #
     # LocalPackage values contain standard file paths — no GUID decompression needed.
+    # Test-Path is intentionally omitted: the HashSet is only compared against Get-ChildItem
+    # output (guaranteed-existing files), so stale registry paths are harmless dead weight.
 
     $referencedFiles = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 
@@ -92,7 +94,7 @@ function Get-OrphanedInstallerFiles {
                         $installProps = Join-Path $product.PSPath "InstallProperties"
                         if (Test-Path $installProps) {
                             $localPackage = (Get-ItemProperty $installProps -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
-                            if ($localPackage -and (Test-Path $localPackage)) {
+                            if ($localPackage) {
                                 [void]$referencedFiles.Add($localPackage)
                             }
                         }
@@ -112,7 +114,7 @@ function Get-OrphanedInstallerFiles {
                 foreach ($patch in (Get-ChildItem $patchesPath -ErrorAction Stop)) {
                     try {
                         $localPackage = (Get-ItemProperty $patch.PSPath -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
-                        if ($localPackage -and (Test-Path $localPackage)) {
+                        if ($localPackage) {
                             [void]$referencedFiles.Add($localPackage)
                         }
                     } catch {
@@ -232,7 +234,9 @@ try {
             try { $winsxsSize += ([System.IO.FileInfo]::new($f)).Length } catch { }
         }
     } catch {
-        $winsxsSize = [long]0
+        # Preserve partial accumulation — $winsxsSize retains bytes counted before the
+        # iterator error. The value is already documented as approximate (hardlink overcount).
+        Write-Warning "WinSxS enumeration interrupted (partial result: $([math]::Round($winsxsSize/1GB,2)) GB): $($_.Exception.Message)"
     }
     $winsxsSizeGB = [math]::Round($winsxsSize / 1GB, 2)
 

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -60,63 +60,69 @@ function Get-OrphanedInstallerFiles {
     param()
 
     $startTime = Get-Date
-    $registryErrors = @()
+    $registryErrors = [System.Collections.Generic.List[string]]::new()
 
     # --- STEP 1: Build the "referenced files" set ---
-    # The Windows Installer stores product/patch cache file references in the registry.
-    # Products: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\{GUID}\InstallProperties
-    #   → "LocalPackage" value = path to cached .msi file
-    # Patches: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Patches\{GUID}
-    #   → "LocalPackage" value = path to cached .msp file
+    # The Windows Installer stores product/patch cache file references in the registry under
+    # HKLM:\...\Installer\UserData\<SID>\Products and \Patches for each SID.
+    # Enumerate ALL SIDs (not just S-1-5-18) to capture per-user installations that also
+    # reference files in C:\Windows\Installer. Missing per-user SIDs inflates orphan counts.
     #
-    # NOTE: Registry GUIDs are in "compressed" format (no dashes, no braces, character reordering).
-    # However, the LocalPackage values contain standard file paths — we do NOT need to decompress
-    # GUIDs. We just collect the LocalPackage values directly.
+    # LocalPackage values contain standard file paths — no GUID decompression needed.
 
     $referencedFiles = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 
-    # Collect referenced MSI files from Products
-    $productsPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products"
+    $userDataPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData"
     try {
-        if (Test-Path $productsPath) {
-            $productGuids = Get-ChildItem $productsPath -ErrorAction Stop
-            foreach ($product in $productGuids) {
-                try {
-                    $installProps = Join-Path $product.PSPath "InstallProperties"
-                    if (Test-Path $installProps) {
-                        $localPackage = (Get-ItemProperty $installProps -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
+        if (-not (Test-Path $userDataPath)) {
+            throw "Installer UserData registry path not found"
+        }
+        $sidKeys = Get-ChildItem $userDataPath -ErrorAction Stop
+    } catch {
+        throw "Failed to read Installer UserData registry path: $($_.Exception.Message)"
+    }
+
+    foreach ($sidKey in $sidKeys) {
+        # Collect referenced MSI files from Products
+        $productsPath = Join-Path $sidKey.PSPath "Products"
+        try {
+            if (Test-Path $productsPath) {
+                foreach ($product in (Get-ChildItem $productsPath -ErrorAction Stop)) {
+                    try {
+                        $installProps = Join-Path $product.PSPath "InstallProperties"
+                        if (Test-Path $installProps) {
+                            $localPackage = (Get-ItemProperty $installProps -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
+                            if ($localPackage -and (Test-Path $localPackage)) {
+                                [void]$referencedFiles.Add($localPackage)
+                            }
+                        }
+                    } catch {
+                        $registryErrors.Add("Product $($product.PSChildName) (SID $($sidKey.PSChildName)): $($_.Exception.Message)")
+                    }
+                }
+            }
+        } catch {
+            $registryErrors.Add("Products key for SID $($sidKey.PSChildName): $($_.Exception.Message)")
+        }
+
+        # Collect referenced MSP files from Patches
+        $patchesPath = Join-Path $sidKey.PSPath "Patches"
+        try {
+            if (Test-Path $patchesPath) {
+                foreach ($patch in (Get-ChildItem $patchesPath -ErrorAction Stop)) {
+                    try {
+                        $localPackage = (Get-ItemProperty $patch.PSPath -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
                         if ($localPackage -and (Test-Path $localPackage)) {
                             [void]$referencedFiles.Add($localPackage)
                         }
+                    } catch {
+                        $registryErrors.Add("Patch $($patch.PSChildName) (SID $($sidKey.PSChildName)): $($_.Exception.Message)")
                     }
-                } catch {
-                    $registryErrors += "Product $($product.PSChildName): $($_.Exception.Message)"
                 }
             }
+        } catch {
+            $registryErrors.Add("Patches key for SID $($sidKey.PSChildName): $($_.Exception.Message)")
         }
-    } catch {
-        # If we can't read the Products key at all, this is a critical failure
-        throw "Failed to read Products registry path: $($_.Exception.Message)"
-    }
-
-    # Collect referenced MSP files from Patches
-    $patchesPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Patches"
-    try {
-        if (Test-Path $patchesPath) {
-            $patchGuids = Get-ChildItem $patchesPath -ErrorAction Stop
-            foreach ($patch in $patchGuids) {
-                try {
-                    $localPackage = (Get-ItemProperty $patch.PSPath -Name "LocalPackage" -ErrorAction SilentlyContinue).LocalPackage
-                    if ($localPackage -and (Test-Path $localPackage)) {
-                        [void]$referencedFiles.Add($localPackage)
-                    }
-                } catch {
-                    $registryErrors += "Patch $($patch.PSChildName): $($_.Exception.Message)"
-                }
-            }
-        }
-    } catch {
-        throw "Failed to read Patches registry path: $($_.Exception.Message)"
     }
 
     # --- STEP 2: Enumerate actual files in C:\Windows\Installer ---
@@ -195,7 +201,7 @@ $patchCacheSizeGB = 0
 $winsxsSizeGB = 0
 $totalFiles = 0
 $scanDurationSec = 0
-$scanErrors = @()
+$scanErrors = [System.Collections.Generic.List[string]]::new()
 
 try {
     # --- Run orphan detection ---
@@ -242,7 +248,7 @@ try {
     }
 } catch {
     $status = "Error"
-    $scanErrors += "Critical scan failure: $($_.Exception.Message)"
+    $scanErrors.Add("Critical scan failure: $($_.Exception.Message)")
     Write-Error "Scan failed: $($_.Exception.Message)"
 }
 

--- a/rmm-ninja/Monitor-InstallerPatches
+++ b/rmm-ninja/Monitor-InstallerPatches
@@ -145,22 +145,24 @@ function Get-OrphanedInstallerFiles {
 
     # --- STEP 4: Measure $PatchCache$ separately ---
     $patchCachePath = Join-Path $installerPath '$PatchCache$'
-    $patchCacheSize = 0
+    $patchCacheSize = [long]0
     if (Test-Path $patchCachePath) {
         $patchCacheSize = (Get-ChildItem $patchCachePath -Recurse -Force -ErrorAction SilentlyContinue |
-            Measure-Object Length -Sum).Sum
+            Measure-Object Length -Sum).Sum -as [long]
+        if (-not $patchCacheSize) { $patchCacheSize = [long]0 }
     }
 
     # --- STEP 5: Return results ---
+    # Null-coerce all Measure-Object .Sum results — .Sum returns $null on empty collections
     [PSCustomObject]@{
-        TotalFiles          = ($allFiles | Measure-Object).Count
-        TotalSizeBytes      = ($allFiles | Measure-Object Length -Sum).Sum
+        TotalFiles          = ($allFiles | Measure-Object).Count -as [int]
+        TotalSizeBytes      = ($allFiles | Measure-Object Length -Sum).Sum -as [long]
         ReferencedFiles     = $referenced
         ReferencedCount     = $referenced.Count
-        ReferencedSizeBytes = ($referenced | Measure-Object SizeBytes -Sum).Sum
+        ReferencedSizeBytes = ($referenced | Measure-Object SizeBytes -Sum).Sum -as [long]
         OrphanedFiles       = $orphaned
         OrphanedCount       = $orphaned.Count
-        OrphanedSizeBytes   = ($orphaned | Measure-Object SizeBytes -Sum).Sum
+        OrphanedSizeBytes   = ($orphaned | Measure-Object SizeBytes -Sum).Sum -as [long]
         PatchCacheSizeBytes = $patchCacheSize
         ScanDuration        = (Get-Date) - $startTime
         Errors              = $errors
@@ -182,29 +184,38 @@ $referencedCount = 0
 $referencedSizeGB = 0
 $patchCacheSizeGB = 0
 $winsxsSizeGB = 0
+$totalFiles = 0
+$scanDurationSec = 0
 $scanErrors = @()
 
 try {
     # --- Run orphan detection ---
     $results = Get-OrphanedInstallerFiles
 
-    $totalSizeGB     = [math]::Round($results.TotalSizeBytes / 1GB, 2)
-    $orphanedSizeGB  = [math]::Round($results.OrphanedSizeBytes / 1GB, 2)
-    $orphanedCount   = $results.OrphanedCount
-    $referencedCount = $results.ReferencedCount
+    $totalSizeGB      = [math]::Round($results.TotalSizeBytes / 1GB, 2)
+    $orphanedSizeGB   = [math]::Round($results.OrphanedSizeBytes / 1GB, 2)
+    $orphanedCount    = $results.OrphanedCount
+    $referencedCount  = $results.ReferencedCount
     $referencedSizeGB = [math]::Round($results.ReferencedSizeBytes / 1GB, 2)
     $patchCacheSizeGB = [math]::Round($results.PatchCacheSizeBytes / 1GB, 2)
-    $scanErrors      = $results.Errors
+    $totalFiles       = $results.TotalFiles
+    $scanDurationSec  = $results.ScanDuration.TotalSeconds
+    $scanErrors       = $results.Errors
 
     # --- Measure WinSxS size (secondary indicator) ---
+    # NOTE: WinSxS uses hardlinks extensively. Recursive enumeration overcounts actual disk
+    # footprint by 2-3x because the same physical data is counted per hardlink. This value
+    # is a rough indicator, not an exact measurement. Use DISM /AnalyzeComponentStore for
+    # precise sizing if needed.
     $winsxsSize = (Get-ChildItem "C:\Windows\WinSxS" -Recurse -Force -ErrorAction SilentlyContinue |
-        Measure-Object Length -Sum).Sum
+        Measure-Object Length -Sum).Sum -as [long]
+    if (-not $winsxsSize) { $winsxsSize = [long]0 }
     $winsxsSizeGB = [math]::Round($winsxsSize / 1GB, 2)
 
     # --- Determine status based on total Installer folder size ---
-    if ($totalSizeGB -gt $CriticalThresholdGB) {
+    if ($totalSizeGB -ge $CriticalThresholdGB) {
         $status = "Critical"
-    } elseif ($totalSizeGB -gt $WarningThresholdGB) {
+    } elseif ($totalSizeGB -ge $WarningThresholdGB) {
         $status = "Warning"
     } else {
         $status = "Healthy"
@@ -235,19 +246,30 @@ try {
 # ============================================================================
 $source = "DTC-InstallerMonitor"
 $logName = "Application"
-if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
-    try {
+# SourceExists() throws SecurityException if caller lacks permission to enumerate sources —
+# wrap in try/catch to prevent script termination
+try {
+    if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
         [System.Diagnostics.EventLog]::CreateEventSource($source, $logName)
-    } catch {
-        # May fail without admin — continue anyway
     }
+} catch {
+    # SourceExists or CreateEventSource may fail without admin — continue anyway
+    Write-Warning "Event source registration skipped: $($_.Exception.Message)"
 }
 
+# Distinct Event IDs per severity for monitoring tool granularity
 $eventId = switch ($status) {
     "Healthy"  { 1000 }
     "Warning"  { 2000 }
-    "Critical" { 2000 }
+    "Critical" { 2500 }
     "Error"    { 3000 }
+}
+# Map EntryType to actual severity so SIEM/monitoring tools can filter
+$entryType = switch ($status) {
+    "Healthy"  { "Information" }
+    "Warning"  { "Warning" }
+    "Critical" { "Error" }
+    "Error"    { "Error" }
 }
 $message = @"
 DTC Installer Patch Monitor — Scan Complete
@@ -256,14 +278,14 @@ Total Installer Folder: $totalSizeGB GB
 Orphaned Files: $orphanedCount ($orphanedSizeGB GB)
 Referenced Files: $referencedCount ($referencedSizeGB GB)
 PatchCache: $patchCacheSizeGB GB
-WinSxS: $winsxsSizeGB GB
-Scan Duration: $($results.ScanDuration.TotalSeconds) seconds
+WinSxS: $winsxsSizeGB GB (approximate — hardlink overcount)
+Scan Duration: $scanDurationSec seconds
 "@
 if ($scanErrors.Count -gt 0) {
     $message += "`nErrors:`n" + ($scanErrors -join "`n")
 }
 try {
-    Write-EventLog -LogName $logName -Source $source -EventId $eventId -EntryType Information -Message $message
+    Write-EventLog -LogName $logName -Source $source -EventId $eventId -EntryType $entryType -Message $message
 } catch {
     Write-Warning "Event log write failed: $($_.Exception.Message)"
 }
@@ -273,12 +295,12 @@ try {
 # ============================================================================
 Write-Output "=== SCAN RESULTS ==="
 Write-Output "Status:             $status"
-Write-Output "Installer Folder:   $totalSizeGB GB ($($results.TotalFiles) files)"
+Write-Output "Installer Folder:   $totalSizeGB GB ($totalFiles files)"
 Write-Output "  Referenced:       $referencedSizeGB GB ($referencedCount files)"
 Write-Output "  Orphaned:         $orphanedSizeGB GB ($orphanedCount files)"
 Write-Output "  PatchCache:       $patchCacheSizeGB GB"
-Write-Output "WinSxS:             $winsxsSizeGB GB"
-Write-Output "Scan Duration:      $($results.ScanDuration.TotalSeconds) seconds"
+Write-Output "WinSxS:             $winsxsSizeGB GB (approximate — hardlink overcount)"
+Write-Output "Scan Duration:      $scanDurationSec seconds"
 if ($scanErrors.Count -gt 0) {
     Write-Output ""
     Write-Output "Non-critical errors ($($scanErrors.Count)):"


### PR DESCRIPTION
Adds Monitor-InstallerPatches.ps1 — a read-only NinjaRMM scheduled script that detects orphaned .msi/.msp files accumulating in C:\Windows\Installer. This folder is not cleaned by Disk Cleanup or DISM and can silently grow to consume entire drives on long-lived dental workstations (ref: HALO Ticket 1125653 — 128 GB orphaned patches, 96.1% disk utilization at Guardian Dentistry Partners).

How orphan detection works:
The script queries the Windows Installer registry database at HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products and \Patches, collecting every LocalPackage value to build a set of referenced cached installers. Any .msi/.msp file in C:\Windows\Installer not in that referenced set is classified as orphaned. This avoids the Win32_Product WMI class entirely, which triggers a reconfigure/consistency check on every installed MSI and can take 20+ minutes while destabilizing applications.

What the script reports:

Total installer folder size, orphaned file count and size, referenced file count and size $PatchCache$ subfolder size
WinSxS size as a secondary disk consumption indicator Status classification: Healthy (<20 GB), Warning (20–50 GB), Critical (>50 GB), or Error on scan failure Where results are written:

Six NinjaRMM custom fields via Ninja-Property-Set (graceful no-op outside NinjaRMM runtime) Windows Application Event Log under source DTC-InstallerMonitor (Event ID 1000 = Healthy, 2000 = Warning/Critical, 3000 = Error) Console output for NinjaRMM script activity log
Safety guarantees:

Makes zero filesystem changes — no files created, moved, or deleted All thresholds defined as variables at script top for easy adjustment Self-contained with no external dependencies (PowerShell 5.1 only) Designed to run as SYSTEM on Windows 10, 11, Server 2019, and Server 2022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly read-only scan to identify orphaned installer (.msi/.msp) files in the system Installer folder
  * Tracks Installer folder, PatchCache and approximate WinSxS size plus orphaned file counts and sizes
  * Automatic health status classification: Healthy / Warning (20GB) / Critical (50GB) with configurable thresholds
  * Writes results to monitoring custom fields, emits a structured Windows Event Log entry, and prints a console summary
  * Robust error handling and reporting for registry access issues and differing run environments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->