### PR TITLE
Add NinjaRMM GUID to Halo PSA GUID Sync Script

### DIFF
--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,0 +1,245 @@
+# Add NinjaRMM DTC ORG GUID to Halo GUID sync script
+
+# ============================================================
+# NinjaRMM → Halo PSA GUID Sync
+# Reads DTC Org GUID from Ninja custom fields and writes
+# it to DTC Client GUID in Halo PSA for all matching clients
+# ============================================================
+
+# --- CONFIGURATION ---
+$HaloClientId     = "YOUR_HALO_CLIENT_ID_IN_1Password"
+$HaloClientSecret = 'YOUR_HALO_CLIENT_SECRET_IN_1Password'
+$HaloBaseUrl      = "https://psa.dtctoday.com"
+$HaloTenant       = "dtctoday"
+$HaloScope        = "read:customers edit:customers"
+
+$NinjaClientId     = "YOUR_NINJA_CLIENT_ID_IN_1Password"
+$NinjaClientSecret = 'YOUR_NINJA_CLIENT_ID_IN_1Password'
+$NinjaBaseUrl      = "https://app.ninjarmm.com"
+
+# --- AUTHENTICATE: HALO ---
+$haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token?tenant=$HaloTenant" -ContentType "application/x-www-form-urlencoded" -Body @{
+    grant_type    = "client_credentials"
+    client_id     = $HaloClientId
+    client_secret = $HaloClientSecret
+    scope         = $HaloScope
+}
+$haloToken = $haloTokenResp.access_token
+if (-not $haloToken) {
+    Write-Host "❌ Halo auth failed — response was:"
+    $haloTokenResp | ConvertTo-Json
+    exit
+}
+Write-Host "✅ Halo authenticated"
+
+# --- AUTHENTICATE: NINJA ---
+$ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" -ContentType "application/x-www-form-urlencoded" -Body @{
+    grant_type    = "client_credentials"
+    client_id     = $NinjaClientId
+    client_secret = $NinjaClientSecret
+    scope         = "monitoring management"
+}
+$ninjaToken = $ninjaTokenResp.access_token
+if (-not $ninjaToken) {
+    Write-Host "❌ Ninja auth failed — response was:"
+    $ninjaTokenResp | ConvertTo-Json
+    exit
+}
+Write-Host "✅ Ninja authenticated"
+
+$ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+$haloHeaders  = @{ Authorization = "Bearer $haloToken" }
+
+# --- GET ALL NINJA ORGS ---
+$ninjaOrgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
+Write-Host "📋 Found $($ninjaOrgs.Count) Ninja orgs"
+
+$results = @()
+
+foreach ($org in $ninjaOrgs) {
+    $orgId   = $org.id
+    $orgName = $org.name
+
+    # Get custom fields for this org
+    try {
+        $fields = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+    } catch {
+        Write-Host "⚠️  Could not get custom fields for $orgName — skipping"
+        continue
+    }
+
+    $guid = $fields.dtcOrgGuid
+    if (-not $guid) {
+        Write-Host "⚠️  No DTC Org GUID set for $orgName — skipping"
+        continue
+    }
+
+    # Find matching Halo client by name
+    $encodedName = [System.Web.HttpUtility]::UrlEncode($orgName)
+    try {
+        $haloSearch = Invoke-RestMethod -Method Get -Uri "$HaloBaseUrl/api/client?search=$encodedName" -Headers $haloHeaders
+    } catch {
+        Write-Host "⚠️  Halo search failed for $orgName — $($_.Exception.Message)"
+        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        continue
+    }
+
+    $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
+
+    if (-not $haloClient) {
+        Write-Host "⚠️  No exact Halo match for '$orgName' — skipping"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No Halo match"; GUID = $guid }
+        continue
+    }
+
+    $haloClientId = $haloClient.id
+
+    # Write GUID to Halo custom field
+    $body = ConvertTo-Json -Depth 5 -InputObject @(
+        [ordered]@{
+            id           = $haloClientId
+            customfields = @(
+                [ordered]@{
+                    name  = "DTC Client GUID"
+                    value = $guid
+                }
+            )
+        }
+    )
+
+    try {
+        $response = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" -Headers $haloHeaders -ContentType "application/json" -Body $body
+        Write-Host "✅ Updated $orgName → $guid"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Updated"; GUID = $guid }
+    } catch {
+        Write-Host "❌ Failed to update $orgName — $($_.Exception.Message)"
+        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Failed"; GUID = $guid }
+    }
+}
+
+# --- SUMMARY ---
+Write-Host ""
+Write-Host "===== SYNC SUMMARY ====="
+$results | Format-Table -AutoSize# ============================================================
+# NinjaRMM → Halo PSA GUID Sync
+# Reads DTC Org GUID from Ninja custom fields and writes
+# it to DTC Client GUID in Halo PSA for all matching clients
+# ============================================================
+
+# --- CONFIGURATION ---
+$HaloClientId     = "25542a6d-2d0e-4093-bf82-e11edc64faf6"
+$HaloClientSecret = '67t5ZMI1p08--LtBe7eAr3xi6-AvT1aowBKzllXYuyA'
+$HaloBaseUrl      = "https://psa.dtctoday.com"
+$HaloTenant       = "dtctoday"
+$HaloScope        = "read:customers edit:customers"
+
+$NinjaClientId     = "0S1xEjce1FQp7Rbn_GJTrSWTp64"
+$NinjaClientSecret = 'z4ExyKaDiIyLKAnEHmo0kG2uwzd2SHV0Dz4zmny7Z8JXWRhPUOjpsA'
+$NinjaBaseUrl      = "https://app.ninjarmm.com"
+
+# --- AUTHENTICATE: HALO ---
+$haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token?tenant=$HaloTenant" -ContentType "application/x-www-form-urlencoded" -Body @{
+    grant_type    = "client_credentials"
+    client_id     = $HaloClientId
+    client_secret = $HaloClientSecret
+    scope         = $HaloScope
+}
+$haloToken = $haloTokenResp.access_token
+if (-not $haloToken) {
+    Write-Host "❌ Halo auth failed — response was:"
+    $haloTokenResp | ConvertTo-Json
+    exit
+}
+Write-Host "✅ Halo authenticated"
+
+# --- AUTHENTICATE: NINJA ---
+$ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" -ContentType "application/x-www-form-urlencoded" -Body @{
+    grant_type    = "client_credentials"
+    client_id     = $NinjaClientId
+    client_secret = $NinjaClientSecret
+    scope         = "monitoring management"
+}
+$ninjaToken = $ninjaTokenResp.access_token
+if (-not $ninjaToken) {
+    Write-Host "❌ Ninja auth failed — response was:"
+    $ninjaTokenResp | ConvertTo-Json
+    exit
+}
+Write-Host "✅ Ninja authenticated"
+
+$ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+$haloHeaders  = @{ Authorization = "Bearer $haloToken" }
+
+# --- GET ALL NINJA ORGS ---
+$ninjaOrgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
+Write-Host "📋 Found $($ninjaOrgs.Count) Ninja orgs"
+
+$results = @()
+
+foreach ($org in $ninjaOrgs) {
+    $orgId   = $org.id
+    $orgName = $org.name
+
+    # Get custom fields for this org
+    try {
+        $fields = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+    } catch {
+        Write-Host "⚠️  Could not get custom fields for $orgName — skipping"
+        continue
+    }
+
+    $guid = $fields.dtcOrgGuid
+    if (-not $guid) {
+        Write-Host "⚠️  No DTC Org GUID set for $orgName — skipping"
+        continue
+    }
+
+    # Find matching Halo client by name
+    $encodedName = [System.Web.HttpUtility]::UrlEncode($orgName)
+    try {
+        $haloSearch = Invoke-RestMethod -Method Get -Uri "$HaloBaseUrl/api/client?search=$encodedName" -Headers $haloHeaders
+    } catch {
+        Write-Host "⚠️  Halo search failed for $orgName — $($_.Exception.Message)"
+        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        continue
+    }
+
+    $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
+
+    if (-not $haloClient) {
+        Write-Host "⚠️  No exact Halo match for '$orgName' — skipping"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No Halo match"; GUID = $guid }
+        continue
+    }
+
+    $haloClientId = $haloClient.id
+
+    # Write GUID to Halo custom field
+    $body = ConvertTo-Json -Depth 5 -InputObject @(
+        [ordered]@{
+            id           = $haloClientId
+            customfields = @(
+                [ordered]@{
+                    name  = "DTC Client GUID"
+                    value = $guid
+                }
+            )
+        }
+    )
+
+    try {
+        $response = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" -Headers $haloHeaders -ContentType "application/json" -Body $body
+        Write-Host "✅ Updated $orgName → $guid"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Updated"; GUID = $guid }
+    } catch {
+        Write-Host "❌ Failed to update $orgName — $($_.Exception.Message)"
+        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Failed"; GUID = $guid }
+    }
+}
+
+# --- SUMMARY ---
+Write-Host ""
+Write-Host "===== SYNC SUMMARY ====="
+$results | Format-Table -AutoSize

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,129 +1,177 @@
-# NinjaRMM to Halo PSA GUID Sync
-# Documentation: BookStack page 1908
-# Schedule: Weekly (Sundays 2:00 AM EDT)
-#
-# Client IDs are not secrets and are hardcoded below.
-# Client secrets are injected at runtime via NinjaRMM Script Variables:
-#   haloclientsecret  — set in Library > Automation > Halo GUID Sync > Script Variables
-#   ninjaclientsecret — set in Library > Automation > Halo GUID Sync > Script Variables
-#
-# Credentials stored in 1Password: Halo/NinjaRMM API - GUID Sync Secret
-# Never commit real secrets to this repository.
+<#
+.SYNOPSIS
+    Syncs DTC Org GUID from NinjaRMM organizations to Halo PSA client custom field.
 
-# --- CONFIGURATION ---
-$HaloClientId      = "25542a6d-2d0e-4093-bf82-e11edc64faf6"
-$HaloClientSecret  = $env:haloclientsecret
-$HaloBaseUrl       = "https://psa.dtctoday.com"
-$HaloScope         = "read:customers edit:customers"
+.DESCRIPTION
+    Reads the dtcOrgGuid custom field from each NinjaRMM organization and writes
+    it to the CFDtcClientGuid field in Halo PSA for all exactly-matched clients.
 
-$NinjaClientId     = "0S1xEjce1FQp7Rbn_GJTrSWTp64"
-$NinjaClientSecret = $env:ninjaclientsecret
-$NinjaBaseUrl      = "https://app.ninjarmm.com"
+    Runs unattended via NinjaOne Scheduled Task (Sundays 2:00 AM EDT).
+    Matching is exact by client name. Name mismatches are logged and skipped.
 
-# --- VALIDATE ---
-$missing = @()
-if ([string]::IsNullOrWhiteSpace($HaloClientSecret))  { $missing += "haloclientsecret" }
-if ([string]::IsNullOrWhiteSpace($NinjaClientSecret)) { $missing += "ninjaclientsecret" }
+.PARAMETER haloclientsecret
+    Halo PSA API client secret. Injected by NinjaOne Script Variable: haloclientsecret.
 
-if ($missing.Count -gt 0) {
-    Write-Error "Missing NinjaRMM Script Variables: $($missing -join ", "). Set default values in Library > Automation > Halo GUID Sync > Script Variables."
-    exit 1
-}
+.PARAMETER ninjaclientsecret
+    NinjaRMM API client secret. Injected by NinjaOne Script Variable: ninjaclientsecret.
 
-# --- AUTHENTICATE: HALO ---
+.NOTES
+    Author:      Tyler Dantzler
+    Repo:        DTC-Inc/msp-script-library/integrations/ninja-halo-guid-sync.ps1
+    BookStack:   Page 1908
+    Schedule:    Weekly, Sundays 2:00 AM EDT (NinjaOne Scheduled Task)
+
+    ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU ARE RUNNING FROM A RMM
+    # $env:RMM             -- set to "1" by NinjaOne at runtime; controls RMM vs interactive mode
+    # $env:Description     -- human-readable audit trail label for this run
+    # $env:haloclientsecret  -- Halo PSA API client secret (NinjaOne Script Variable)
+    # $env:ninjaclientsecret -- NinjaRMM API client secret (NinjaOne Script Variable)
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+# --- AUDIT TRAIL & LOGGING ---
+$ScriptLogName = 'ninja-halo-guid-sync'
+$Description   = if ($env:Description) { $env:Description } else { 'NinjaRMM to Halo PSA GUID sync (manual run)' }
+$logPath       = "C:\ProgramData\DTC\Logs\$ScriptLogName-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+New-Item -ItemType Directory -Path (Split-Path $logPath) -Force | Out-Null
+Start-Transcript -Path $logPath -Append
+
+Write-Information "[$ScriptLogName] Starting — $Description" -InformationAction Continue
+
 try {
+
+    # --- CONFIGURATION ---
+    # Client IDs are not secrets — hardcoded here.
+    # Client secrets are injected via NinjaOne Script Variables (env vars at runtime).
+    $HaloClientId      = '25542a6d-2d0e-4093-bf82-e11edc64faf6'
+    $HaloClientSecret  = $env:haloclientsecret
+    $HaloBaseUrl       = 'https://psa.dtctoday.com'
+    $HaloScope         = 'read:customers edit:customers'
+
+    $NinjaClientId     = '0S1xEjce1FQp7Rbn_GJTrSWTp64'
+    $NinjaClientSecret = $env:ninjaclientsecret
+    $NinjaBaseUrl      = 'https://app.ninjarmm.com'
+
+    # --- VALIDATE SECRETS ---
+    $missing = @()
+    if ([string]::IsNullOrWhiteSpace($HaloClientSecret))  { $missing += 'haloclientsecret' }
+    if ([string]::IsNullOrWhiteSpace($NinjaClientSecret)) { $missing += 'ninjaclientsecret' }
+
+    if ($missing.Count -gt 0) {
+        throw "Missing NinjaOne Script Variables: $($missing -join ', '). Set default values in Library > Automation > Halo GUID Sync > Script Variables."
+    }
+
+    # --- AUTHENTICATE: HALO ---
+    Write-Information '  Authenticating with Halo PSA...' -InformationAction Continue
     $haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token" `
-        -ContentType "application/x-www-form-urlencoded" -Body @{
-            grant_type    = "client_credentials"
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
             client_id     = $HaloClientId
             client_secret = $HaloClientSecret
             scope         = $HaloScope
         }
     $haloToken   = $haloTokenResp.access_token
     $haloHeaders = @{ Authorization = "Bearer $haloToken" }
-} catch {
-    Write-Error "Halo auth failed: $($_.Exception.Message)"
-    exit 1
-}
+    Write-Information '  Halo auth OK' -InformationAction Continue
 
-# --- AUTHENTICATE: NINJA ---
-try {
+    # --- AUTHENTICATE: NINJA ---
+    Write-Information '  Authenticating with NinjaRMM...' -InformationAction Continue
     $ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" `
-        -ContentType "application/x-www-form-urlencoded" -Body @{
-            grant_type    = "client_credentials"
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
             client_id     = $NinjaClientId
             client_secret = $NinjaClientSecret
-            scope         = "monitoring management"
+            scope         = 'monitoring management'
         }
     $ninjaToken   = $ninjaTokenResp.access_token
     $ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+    Write-Information '  Ninja auth OK' -InformationAction Continue
+
+    # --- PULL NINJA ORGS ---
+    $orgs    = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
+    $results = @()
+
+    foreach ($org in $orgs) {
+        $orgName = $org.name
+        $orgId   = $org.id
+
+        # Read DTC Org GUID custom field
+        try {
+            $cf   = Invoke-RestMethod -Method Get `
+                -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+            $guid = $cf.dtcOrgGuid
+        } catch {
+            Write-Warning "Could not read custom fields for '$orgName' — skipping"
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($guid)) {
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No GUID'; GUID = '' }
+            continue
+        }
+
+        # Search Halo for matching client by exact name
+        try {
+            $haloSearch = Invoke-RestMethod -Method Get `
+                -Uri "$HaloBaseUrl/api/client?search=$([uri]::EscapeDataString($orgName))" `
+                -Headers $haloHeaders
+        } catch {
+            Write-Warning "Halo search failed for '$orgName' — skipping"
+            continue
+        }
+
+        $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
+
+        if (-not $haloClient) {
+            Write-Warning "No exact Halo match for '$orgName' — skipping"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No Halo match'; GUID = $guid }
+            continue
+        }
+
+        # Build body — PowerShell 5 unwraps single-item @() on ConvertTo-Json so manually wrap in []
+        $clientUpdate = @{
+            id           = $haloClient.id
+            customfields = @(
+                @{ name = 'CFDtcClientGuid'; value = $guid }
+            )
+        }
+        $body = '[' + ($clientUpdate | ConvertTo-Json -Depth 5) + ']'
+
+        try {
+            Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" `
+                -Headers $haloHeaders -ContentType 'application/json' -Body $body | Out-Null
+            Write-Information "  [OK] $orgName" -InformationAction Continue
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Updated'; GUID = $guid }
+        } catch {
+            $errorDetail = $_.ErrorDetails.Message
+            Write-Warning "Failed to update '$orgName' — $($_.Exception.Message) | $errorDetail"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Failed'; GUID = $guid }
+        }
+    }
+
+    # --- SUMMARY ---
+    Write-Information '' -InformationAction Continue
+    Write-Information '===== SYNC SUMMARY =====' -InformationAction Continue
+    $results | Format-Table -AutoSize
+
+    $failed = $results | Where-Object { $_.Status -eq 'Failed' }
+    if ($failed) {
+        Write-Warning "$($failed.Count) client(s) failed to update — see above"
+        exit 2
+    }
+
+    Write-Information "[$ScriptLogName] Completed successfully." -InformationAction Continue
+    exit 0
+
 } catch {
-    Write-Error "Ninja auth failed: $($_.Exception.Message)"
+    Write-Error "FAILED: $_"
+    Write-Error $_.ScriptStackTrace
     exit 1
+} finally {
+    Stop-Transcript
 }
-
-# --- PULL NINJA ORGS ---
-$orgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
-
-$results = @()
-
-foreach ($org in $orgs) {
-    $orgName = $org.name
-    $orgId   = $org.id
-
-    try {
-        $cf   = Invoke-RestMethod -Method Get `
-            -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
-        $guid = $cf.dtcOrgGuid
-    } catch {
-        Write-Host "Could not read custom fields for $orgName -- skipping"
-        continue
-    }
-
-    if ([string]::IsNullOrWhiteSpace($guid)) {
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No GUID"; GUID = "" }
-        continue
-    }
-
-    try {
-        $haloSearch = Invoke-RestMethod -Method Get `
-            -Uri "$HaloBaseUrl/api/client?search=$([uri]::EscapeDataString($orgName))" `
-            -Headers $haloHeaders
-    } catch {
-        Write-Host "Halo search failed for $orgName -- skipping"
-        continue
-    }
-
-    $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
-
-    if (-not $haloClient) {
-        Write-Host "No exact Halo match for $orgName -- skipping"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No Halo match"; GUID = $guid }
-        continue
-    }
-
-    # Body must be a JSON array per Halo API requirements
-    # PowerShell 5 unwraps single-item @() on ConvertTo-Json so we manually wrap
-    $clientUpdate = @{
-        id           = $haloClient.id
-        customfields = @(
-            @{ name = "CFDtcClientGuid"; value = $guid }
-        )
-    }
-    $body = "[" + ($clientUpdate | ConvertTo-Json -Depth 5) + "]"
-
-    try {
-        Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" `
-            -Headers $haloHeaders -ContentType "application/json" -Body $body | Out-Null
-        Write-Host "Updated $orgName"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Updated"; GUID = $guid }
-    } catch {
-        $errorDetail = $_.ErrorDetails.Message
-        Write-Host "Failed to update $orgName -- $($_.Exception.Message) | $errorDetail"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Failed"; GUID = $guid }
-    }
-}
-
-Write-Host ""
-Write-Host "===== SYNC SUMMARY ====="
-$results | Format-Table -AutoSize

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -14,7 +14,7 @@ $HaloTenant       = "dtctoday"
 $HaloScope        = "read:customers edit:customers"
 
 $NinjaClientId     = "YOUR_NINJA_CLIENT_ID_IN_1Password"
-$NinjaClientSecret = 'YOUR_NINJA_CLIENT_ID_IN_1Password'
+$NinjaClientSecret = 'YOUR_NINJA_CLIENT_SECRET_IN_1Password'
 $NinjaBaseUrl      = "https://app.ninjarmm.com"
 
 # --- AUTHENTICATE: HALO ---

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,245 +1,119 @@
-# Add NinjaRMM DTC ORG GUID to Halo GUID sync script
-
-# ============================================================
-# NinjaRMM → Halo PSA GUID Sync
-# Reads DTC Org GUID from Ninja custom fields and writes
-# it to DTC Client GUID in Halo PSA for all matching clients
-# ============================================================
+# NinjaRMM to Halo PSA GUID Sync
+#
+# SYNOPSIS
+#   Syncs the DTC Org GUID from NinjaRMM organizations to the DTC Client GUID
+#   custom field in Halo PSA.
+#
+# NOTES
+#   Documentation: BookStack page 1908
+#   Schedule:      Weekly (Sundays 2:00 AM EDT) via NinjaRMM Scheduled Tasks
+#
+#   Replace all placeholder values below with real credentials before deploying.
+#   Store credentials in 1Password under: Halo/NinjaRMM API - GUID Sync Secret
+#   Never commit real credentials to this repository.
 
 # --- CONFIGURATION ---
-$HaloClientId     = "YOUR_HALO_CLIENT_ID_IN_1Password"
-$HaloClientSecret = 'YOUR_HALO_CLIENT_SECRET_IN_1Password'
-$HaloBaseUrl      = "https://psa.dtctoday.com"
-$HaloTenant       = "dtctoday"
-$HaloScope        = "read:customers edit:customers"
+$HaloClientId      = "YOUR_HALO_CLIENT_ID"
+$HaloClientSecret  = "YOUR_HALO_CLIENT_SECRET"
+$HaloBaseUrl       = "https://psa.dtctoday.com"
+$HaloScope         = "read:customers edit:customers"
 
-$NinjaClientId     = "YOUR_NINJA_CLIENT_ID_IN_1Password"
-$NinjaClientSecret = 'YOUR_NINJA_CLIENT_SECRET_IN_1Password'
+$NinjaClientId     = "YOUR_NINJA_CLIENT_ID"
+$NinjaClientSecret = "YOUR_NINJA_CLIENT_SECRET"
 $NinjaBaseUrl      = "https://app.ninjarmm.com"
 
 # --- AUTHENTICATE: HALO ---
-$haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token?tenant=$HaloTenant" -ContentType "application/x-www-form-urlencoded" -Body @{
-    grant_type    = "client_credentials"
-    client_id     = $HaloClientId
-    client_secret = $HaloClientSecret
-    scope         = $HaloScope
+try {
+    $haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token" `
+        -ContentType "application/x-www-form-urlencoded" -Body @{
+            grant_type    = "client_credentials"
+            client_id     = $HaloClientId
+            client_secret = $HaloClientSecret
+            scope         = $HaloScope
+        }
+    $haloToken   = $haloTokenResp.access_token
+    $haloHeaders = @{ Authorization = "Bearer $haloToken" }
+} catch {
+    Write-Error "Halo auth failed: $($_.Exception.Message)"
+    exit 1
 }
-$haloToken = $haloTokenResp.access_token
-if (-not $haloToken) {
-    Write-Host "❌ Halo auth failed — response was:"
-    $haloTokenResp | ConvertTo-Json
-    exit
-}
-Write-Host "✅ Halo authenticated"
 
 # --- AUTHENTICATE: NINJA ---
-$ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" -ContentType "application/x-www-form-urlencoded" -Body @{
-    grant_type    = "client_credentials"
-    client_id     = $NinjaClientId
-    client_secret = $NinjaClientSecret
-    scope         = "monitoring management"
+try {
+    $ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" `
+        -ContentType "application/x-www-form-urlencoded" -Body @{
+            grant_type    = "client_credentials"
+            client_id     = $NinjaClientId
+            client_secret = $NinjaClientSecret
+            scope         = "monitoring management"
+        }
+    $ninjaToken   = $ninjaTokenResp.access_token
+    $ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+} catch {
+    Write-Error "Ninja auth failed: $($_.Exception.Message)"
+    exit 1
 }
-$ninjaToken = $ninjaTokenResp.access_token
-if (-not $ninjaToken) {
-    Write-Host "❌ Ninja auth failed — response was:"
-    $ninjaTokenResp | ConvertTo-Json
-    exit
-}
-Write-Host "✅ Ninja authenticated"
 
-$ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
-$haloHeaders  = @{ Authorization = "Bearer $haloToken" }
-
-# --- GET ALL NINJA ORGS ---
-$ninjaOrgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
-Write-Host "📋 Found $($ninjaOrgs.Count) Ninja orgs"
+# --- PULL NINJA ORGS ---
+$orgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
 
 $results = @()
 
-foreach ($org in $ninjaOrgs) {
-    $orgId   = $org.id
+foreach ($org in $orgs) {
     $orgName = $org.name
+    $orgId   = $org.id
 
-    # Get custom fields for this org
     try {
-        $fields = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+        $cf   = Invoke-RestMethod -Method Get `
+            -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+        $guid = $cf.dtcOrgGuid
     } catch {
-        Write-Host "⚠️  Could not get custom fields for $orgName — skipping"
+        Write-Host "Could not read custom fields for $orgName -- skipping"
         continue
     }
 
-    $guid = $fields.dtcOrgGuid
-    if (-not $guid) {
-        Write-Host "⚠️  No DTC Org GUID set for $orgName — skipping"
+    if ([string]::IsNullOrWhiteSpace($guid)) {
+        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No GUID"; GUID = "" }
         continue
     }
 
-    # Find matching Halo client by name
-    $encodedName = [System.Web.HttpUtility]::UrlEncode($orgName)
     try {
-        $haloSearch = Invoke-RestMethod -Method Get -Uri "$HaloBaseUrl/api/client?search=$encodedName" -Headers $haloHeaders
+        $haloSearch = Invoke-RestMethod -Method Get `
+            -Uri "$HaloBaseUrl/api/client?search=$([uri]::EscapeDataString($orgName))" `
+            -Headers $haloHeaders
     } catch {
-        Write-Host "⚠️  Halo search failed for $orgName — $($_.Exception.Message)"
-        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        Write-Host "Halo search failed for $orgName -- skipping"
         continue
     }
 
     $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
 
     if (-not $haloClient) {
-        Write-Host "⚠️  No exact Halo match for '$orgName' — skipping"
+        Write-Host "No exact Halo match for $orgName -- skipping"
         $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No Halo match"; GUID = $guid }
         continue
     }
 
-    $haloClientId = $haloClient.id
-
-    # Write GUID to Halo custom field
-    $body = ConvertTo-Json -Depth 5 -InputObject @(
-        [ordered]@{
-            id           = $haloClientId
-            customfields = @(
-                [ordered]@{
-                    name  = "CFDtcClientGuid"
-                    value = $guid
-                }
-            )
-        }
-    )
+    $clientUpdate = @{
+        id           = $haloClient.id
+        customfields = @(
+            @{ name = "CFDtcClientGuid"; value = $guid }
+        )
+    }
+    $body = "[" + ($clientUpdate | ConvertTo-Json -Depth 5) + "]"
 
     try {
-        $response = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" -Headers $haloHeaders -ContentType "application/json" -Body $body
-        Write-Host "✅ Updated $orgName → $guid"
+        Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" `
+            -Headers $haloHeaders -ContentType "application/json" -Body $body | Out-Null
+        Write-Host "Updated $orgName"
         $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Updated"; GUID = $guid }
     } catch {
-        Write-Host "❌ Failed to update $orgName — $($_.Exception.Message)"
-        Write-Host "    Response: $($_.ErrorDetails.Message)"
+        $errorDetail = $_.ErrorDetails.Message
+        Write-Host "Failed to update $orgName -- $($_.Exception.Message) | $errorDetail"
         $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Failed"; GUID = $guid }
     }
 }
 
-# --- SUMMARY ---
-Write-Host ""
-Write-Host "===== SYNC SUMMARY ====="
-$results | Format-Table -AutoSize# ============================================================
-# NinjaRMM → Halo PSA GUID Sync
-# Reads DTC Org GUID from Ninja custom fields and writes
-# it to DTC Client GUID in Halo PSA for all matching clients
-# ============================================================
-
-# --- CONFIGURATION ---
-$HaloClientId     = "25542a6d-2d0e-4093-bf82-e11edc64faf6"
-$HaloClientSecret = '67t5ZMI1p08--LtBe7eAr3xi6-AvT1aowBKzllXYuyA'
-$HaloBaseUrl      = "https://psa.dtctoday.com"
-$HaloTenant       = "dtctoday"
-$HaloScope        = "read:customers edit:customers"
-
-$NinjaClientId     = "0S1xEjce1FQp7Rbn_GJTrSWTp64"
-$NinjaClientSecret = 'z4ExyKaDiIyLKAnEHmo0kG2uwzd2SHV0Dz4zmny7Z8JXWRhPUOjpsA'
-$NinjaBaseUrl      = "https://app.ninjarmm.com"
-
-# --- AUTHENTICATE: HALO ---
-$haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token?tenant=$HaloTenant" -ContentType "application/x-www-form-urlencoded" -Body @{
-    grant_type    = "client_credentials"
-    client_id     = $HaloClientId
-    client_secret = $HaloClientSecret
-    scope         = $HaloScope
-}
-$haloToken = $haloTokenResp.access_token
-if (-not $haloToken) {
-    Write-Host "❌ Halo auth failed — response was:"
-    $haloTokenResp | ConvertTo-Json
-    exit
-}
-Write-Host "✅ Halo authenticated"
-
-# --- AUTHENTICATE: NINJA ---
-$ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" -ContentType "application/x-www-form-urlencoded" -Body @{
-    grant_type    = "client_credentials"
-    client_id     = $NinjaClientId
-    client_secret = $NinjaClientSecret
-    scope         = "monitoring management"
-}
-$ninjaToken = $ninjaTokenResp.access_token
-if (-not $ninjaToken) {
-    Write-Host "❌ Ninja auth failed — response was:"
-    $ninjaTokenResp | ConvertTo-Json
-    exit
-}
-Write-Host "✅ Ninja authenticated"
-
-$ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
-$haloHeaders  = @{ Authorization = "Bearer $haloToken" }
-
-# --- GET ALL NINJA ORGS ---
-$ninjaOrgs = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
-Write-Host "📋 Found $($ninjaOrgs.Count) Ninja orgs"
-
-$results = @()
-
-foreach ($org in $ninjaOrgs) {
-    $orgId   = $org.id
-    $orgName = $org.name
-
-    # Get custom fields for this org
-    try {
-        $fields = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
-    } catch {
-        Write-Host "⚠️  Could not get custom fields for $orgName — skipping"
-        continue
-    }
-
-    $guid = $fields.dtcOrgGuid
-    if (-not $guid) {
-        Write-Host "⚠️  No DTC Org GUID set for $orgName — skipping"
-        continue
-    }
-
-    # Find matching Halo client by name
-    $encodedName = [System.Web.HttpUtility]::UrlEncode($orgName)
-    try {
-        $haloSearch = Invoke-RestMethod -Method Get -Uri "$HaloBaseUrl/api/client?search=$encodedName" -Headers $haloHeaders
-    } catch {
-        Write-Host "⚠️  Halo search failed for $orgName — $($_.Exception.Message)"
-        Write-Host "    Response: $($_.ErrorDetails.Message)"
-        continue
-    }
-
-    $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
-
-    if (-not $haloClient) {
-        Write-Host "⚠️  No exact Halo match for '$orgName' — skipping"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "No Halo match"; GUID = $guid }
-        continue
-    }
-
-    $haloClientId = $haloClient.id
-
-    # Write GUID to Halo custom field
-    $body = ConvertTo-Json -Depth 5 -InputObject @(
-        [ordered]@{
-            id           = $haloClientId
-            customfields = @(
-                [ordered]@{
-                    name  = "DTC Client GUID"
-                    value = $guid
-                }
-            )
-        }
-    )
-
-    try {
-        $response = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" -Headers $haloHeaders -ContentType "application/json" -Body $body
-        Write-Host "✅ Updated $orgName → $guid"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Updated"; GUID = $guid }
-    } catch {
-        Write-Host "❌ Failed to update $orgName — $($_.Exception.Message)"
-        Write-Host "    Response: $($_.ErrorDetails.Message)"
-        $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = "Failed"; GUID = $guid }
-    }
-}
-
-# --- SUMMARY ---
 Write-Host ""
 Write-Host "===== SYNC SUMMARY ====="
 $results | Format-Table -AutoSize

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -100,7 +100,7 @@ foreach ($org in $ninjaOrgs) {
             id           = $haloClientId
             customfields = @(
                 [ordered]@{
-                    name  = "DTC Client GUID"
+                    name  = "CFDtcClientGuid"
                     value = $guid
                 }
             )

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,26 +1,34 @@
 # NinjaRMM to Halo PSA GUID Sync
+# Documentation: BookStack page 1908
+# Schedule: Weekly (Sundays 2:00 AM EDT)
 #
-# SYNOPSIS
-#   Syncs the DTC Org GUID from NinjaRMM organizations to the DTC Client GUID
-#   custom field in Halo PSA.
+# Client IDs are not secrets and are hardcoded below.
+# Client secrets are injected at runtime via NinjaRMM Script Variables:
+#   haloclientsecret  — set in Library > Automation > Halo GUID Sync > Script Variables
+#   ninjaclientsecret — set in Library > Automation > Halo GUID Sync > Script Variables
 #
-# NOTES
-#   Documentation: BookStack page 1908
-#   Schedule:      Weekly (Sundays 2:00 AM EDT) via NinjaRMM Scheduled Tasks
-#
-#   Replace all placeholder values below with real credentials before deploying.
-#   Store credentials in 1Password under: Halo/NinjaRMM API - GUID Sync Secret
-#   Never commit real credentials to this repository.
+# Credentials stored in 1Password: Halo/NinjaRMM API - GUID Sync Secret
+# Never commit real secrets to this repository.
 
 # --- CONFIGURATION ---
-$HaloClientId      = "YOUR_HALO_CLIENT_ID"
-$HaloClientSecret  = "YOUR_HALO_CLIENT_SECRET"
+$HaloClientId      = "25542a6d-2d0e-4093-bf82-e11edc64faf6"
+$HaloClientSecret  = $env:haloclientsecret
 $HaloBaseUrl       = "https://psa.dtctoday.com"
 $HaloScope         = "read:customers edit:customers"
 
-$NinjaClientId     = "YOUR_NINJA_CLIENT_ID"
-$NinjaClientSecret = "YOUR_NINJA_CLIENT_SECRET"
+$NinjaClientId     = "0S1xEjce1FQp7Rbn_GJTrSWTp64"
+$NinjaClientSecret = $env:ninjaclientsecret
 $NinjaBaseUrl      = "https://app.ninjarmm.com"
+
+# --- VALIDATE ---
+$missing = @()
+if ([string]::IsNullOrWhiteSpace($HaloClientSecret))  { $missing += "haloclientsecret" }
+if ([string]::IsNullOrWhiteSpace($NinjaClientSecret)) { $missing += "ninjaclientsecret" }
+
+if ($missing.Count -gt 0) {
+    Write-Error "Missing NinjaRMM Script Variables: $($missing -join ", "). Set default values in Library > Automation > Halo GUID Sync > Script Variables."
+    exit 1
+}
 
 # --- AUTHENTICATE: HALO ---
 try {
@@ -94,6 +102,8 @@ foreach ($org in $orgs) {
         continue
     }
 
+    # Body must be a JSON array per Halo API requirements
+    # PowerShell 5 unwraps single-item @() on ConvertTo-Json so we manually wrap
     $clientUpdate = @{
         id           = $haloClient.id
         customfields = @(


### PR DESCRIPTION
Syncs DTC Org GUID from NinjaRMM custom fields to DTC Client GUID field in Halo PSA for all matching clients by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated synchronization between NinjaRMM and Halo PSA to match organizations and update client identifiers, reducing manual data maintenance.
  * Provides per-organization result reporting during the run and a final sync summary table so admins can review matched, updated, or unmatched records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->