### PR TITLE
Clarify naming conventions: kebab for filesystem/URLs, camelCase for code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This library contains scripts that any MSP should be able to deploy. Every scrip
 
 For deep architectural detail, see [`CLAUDE.md`](CLAUDE.md). For PR workflow and branch conventions, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+## Naming Conventions
+
+Two axes, don't conflate them:
+
+- **Code identifiers** (variables, functions, parameters): camelCase by default unless the language specifies otherwise. PowerShell uses PascalCase for functions and camelCase for variables; Python uses snake_case.
+- **Filesystem and URLs** (file names, folder names, log names, paths, slugs): kebab-case. This includes script files, log files, and any artifact written to disk or referenced by URL.
+
+Folders follow `category-vendor` or `category-app` (kebab-case throughout). File names are lowercase with hyphens (e.g., `chrome-remote-desktop-detect-system.ps1`). Kebab-case is shell-friendly (no quoting), URL-safe, and forces a clean split between "this is a path/slug" vs "this is a code identifier."
+
 ## Quick Start
 
 **Run a script interactively** (for testing or one-off use):
@@ -47,7 +56,7 @@ Scripts are organized by category prefix:
 | `sec-*` | Security tools (Huntress, CrowdStrike Falcon, Cynet) |
 | `s3-api-lib/` | Reusable S3 API function library |
 
-Folder names follow `category-vendor` or `category-app` (e.g., `app-google-chrome`, `bdr-veeam`). File names are lowercase with hyphens (e.g., `chrome-remote-desktop-detect-system.ps1`).
+See [Naming Conventions](#naming-conventions) above for folder and file naming rules.
 
 ## Script Conventions
 


### PR DESCRIPTION
## Summary

Splits the README's naming guidance into two clear axes that were previously conflated:
- **Code identifiers** → camelCase (or whatever the language dictates: PascalCase for PS functions, snake_case for Python)
- **Filesystem and URLs** → kebab-case (filenames, log names, folder names, paths, slugs)

## Why

The original wording "We develop in camelCase only" was applied across the board, but kebab-case has actually been the convention for folders (`app-adobe`, `bdr-veeam`, `iaas-azure`, etc.) since the repo started, and we want kebab-case for new filenames and log names too. Kebab-case is shell-friendly (no quoting), URL-safe (RFC 3986 unreserved), and forces a clean split between "this is a path/slug" vs "this is a code identifier."

This came up while reviewing PR #31 — I initially flagged a kebab-case log filename as a "violation" against the README, then realized the README itself was the misalignment.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] No code or script changes; pure docs

## Notes

- Existing folder names already follow this convention; nothing in the repo needs renaming.
- Per `CLAUDE.md` this kind of doc update would normally be eligible for direct-to-main, but branch protection requires PR — fine, going through the regular flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with standardized naming conventions for code identifiers (camelCase), filesystem and URL strings (kebab-case), and folder structure for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->