### PR TITLE
Add RDS 90-day logon report script

### DIFF
--- a/msft-windows/msft-windows-rds-logon-report.ps1
+++ b/msft-windows/msft-windows-rds-logon-report.ps1
@@ -1,0 +1,129 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $DaysBack       - Number of days of history to pull (default: 90)
+## $OutputFolder   - Folder to write the CSV to (default: C:\temp)
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "msft-windows-rds-logon-report.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+}
+
+# Defaults for parameters that may be set by the RMM or left empty interactively.
+if (-not $DaysBack)     { $DaysBack = 90 }
+if (-not $OutputFolder) { $OutputFolder = "C:\temp" }
+
+# Start the script logic here.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+Write-Host "DaysBack: $DaysBack"
+Write-Host "OutputFolder: $OutputFolder"
+
+# Ensure output folder exists.
+if (-not (Test-Path -Path $OutputFolder)) {
+    Write-Host "Creating output folder $OutputFolder"
+    New-Item -Path $OutputFolder -ItemType Directory -Force | Out-Null
+}
+
+$computerName = $env:COMPUTERNAME
+$startTime    = (Get-Date).AddDays(-[int]$DaysBack)
+$timestamp    = Get-Date -Format "yyyyMMdd-HHmmss"
+$csvPath      = Join-Path $OutputFolder ("rds-logons-{0}-{1}days-{2}.csv" -f $computerName, $DaysBack, $timestamp)
+
+Write-Host "Querying RDS logon events since $startTime on $computerName"
+
+# Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
+#   21 = Remote Desktop Services: Session logon succeeded
+#   25 = Remote Desktop Services: Session reconnection succeeded
+$filter = @{
+    LogName   = 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'
+    Id        = 21, 25
+    StartTime = $startTime
+}
+
+try {
+    $events = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop
+} catch {
+    if ($_.Exception.Message -match 'No events were found') {
+        Write-Host "No RDS logon events found in the last $DaysBack days."
+        $events = @()
+    } else {
+        Write-Host "Failed to query event log: $($_.Exception.Message)"
+        Stop-Transcript
+        exit 1
+    }
+}
+
+Write-Host "Found $($events.Count) events. Parsing..."
+
+$results = foreach ($event in $events) {
+    # The LSM events store User / SessionID / Address inside UserData/EventXML.
+    $xml = [xml]$event.ToXml()
+    $data = $xml.Event.UserData.EventXML
+
+    $eventType = switch ($event.Id) {
+        21 { 'Logon' }
+        25 { 'Reconnect' }
+        default { "Id$($event.Id)" }
+    }
+
+    [pscustomobject]@{
+        TimeCreated = $event.TimeCreated
+        Computer    = $computerName
+        EventId     = $event.Id
+        EventType   = $eventType
+        User        = $data.User
+        SessionID   = $data.SessionID
+        SourceIP    = $data.Address
+    }
+}
+
+$results = $results | Sort-Object TimeCreated -Descending
+
+if ($results) {
+    $results | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Wrote $($results.Count) rows to $csvPath"
+} else {
+    # Still produce an empty CSV with headers so the artifact exists.
+    [pscustomobject]@{
+        TimeCreated = $null
+        Computer    = $computerName
+        EventId     = $null
+        EventType   = $null
+        User        = $null
+        SessionID   = $null
+        SourceIP    = $null
+    } | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
+    # Re-write without the placeholder row.
+    "TimeCreated,Computer,EventId,EventType,User,SessionID,SourceIP" | Set-Content -Path $csvPath -Encoding UTF8
+    Write-Host "No events to export. Empty CSV written to $csvPath"
+}
+
+Stop-Transcript

--- a/msft-windows/msft-windows-rds-logon-report.ps1
+++ b/msft-windows/msft-windows-rds-logon-report.ps1
@@ -7,6 +7,21 @@
 
 $ScriptLogName = "msft-windows-rds-logon-report.log"
 
+# Auto-detect non-interactive PowerShell (e.g. NinjaOne, Datto, scheduled tasks).
+# When -NonInteractive is on the command line, Read-Host throws and would kill the
+# script, so treat that as RMM mode even if $RMM was not explicitly passed.
+try {
+    $cmdLineArgs = [Environment]::GetCommandLineArgs()
+    if ($cmdLineArgs | Where-Object { $_ -match '^-NonInteractive$' }) {
+        if ($RMM -ne 1) {
+            Write-Host "Non-interactive PowerShell detected; treating as RMM mode."
+            $RMM = 1
+        }
+    }
+} catch {
+    # If detection itself fails, leave $RMM as-is and proceed.
+}
+
 if ($RMM -ne 1) {
     $ValidInput = 0
     while ($ValidInput -ne 1) {

--- a/msft-windows/msft-windows-rds-logon-report.ps1
+++ b/msft-windows/msft-windows-rds-logon-report.ps1
@@ -101,9 +101,9 @@ if (-not (Test-Path -Path $OutputFolder)) {
 }
 
 $computerName = $env:COMPUTERNAME
-$startTime    = (Get-Date).AddDays(-[int]$DaysBack)
-$timestamp    = Get-Date -Format "yyyyMMdd-HHmmss"
-$csvPath      = Join-Path $OutputFolder ("rds-logons-{0}-{1}days-{2}.csv" -f $computerName, $DaysBack, $timestamp)
+$now          = Get-Date
+$startTime    = $now.AddDays(-[int]$DaysBack)
+$timestamp    = $now.ToString("yyyyMMdd-HHmmss")
 
 # Fail fast if the LSM log is missing/disabled (e.g. running on a non-RDS host).
 $lsmLogName = 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'
@@ -165,21 +165,23 @@ $results = foreach ($event in $events) {
 
 $results = @($results | Sort-Object TimeCreated -Descending)
 
+# Name the CSV based on the actual span of data retrieved, not the requested $DaysBack.
+# Example: requested 90 days, LSM log only retained 14 -> filename shows "14days".
+if ($results.Count -gt 0) {
+    $oldestEvent = ($results | Select-Object -Last 1).TimeCreated
+    $actualDays  = [int][math]::Ceiling(($now - $oldestEvent).TotalDays)
+    if ($actualDays -lt 1) { $actualDays = 1 }
+} else {
+    $actualDays = 0
+}
+$csvPath = Join-Path $OutputFolder ("rds-logons-{0}-{1}days-{2}.csv" -f $computerName, $actualDays, $timestamp)
+Write-Host "Requested $DaysBack days, retrieved $actualDays days of data; CSV: $csvPath"
+
 if ($results.Count -gt 0) {
     $results | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-Host "Wrote $($results.Count) rows to $csvPath"
 } else {
     # Still produce an empty CSV with headers so the artifact exists.
-    [pscustomobject]@{
-        TimeCreated = $null
-        Computer    = $computerName
-        EventId     = $null
-        EventType   = $null
-        User        = $null
-        SessionID   = $null
-        SourceIP    = $null
-    } | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-    # Re-write without the placeholder row.
     "TimeCreated,Computer,EventId,EventType,User,SessionID,SourceIP" | Set-Content -Path $csvPath -Encoding UTF8
     Write-Host "No events to export. Empty CSV written to $csvPath"
 }

--- a/msft-windows/msft-windows-rds-logon-report.ps1
+++ b/msft-windows/msft-windows-rds-logon-report.ps1
@@ -20,7 +20,8 @@ if ($RMM -ne 1) {
     $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
 
 } else {
-    if ($null -eq $RMMScriptPath) {
+    # Prefer RMMScriptPath when the RMM provides one (e.g. Datto), otherwise fall back to WINDIR.
+    if ($RMMScriptPath) {
         $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
     } else {
         $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
@@ -36,20 +37,52 @@ if ($RMM -ne 1) {
 if (-not $DaysBack)     { $DaysBack = 90 }
 if (-not $OutputFolder) { $OutputFolder = "C:\temp" }
 
-# Start the script logic here.
-
-Start-Transcript -Path $LogPath
-
+# Emit progress to stdout BEFORE the transcript starts, so even if Start-Transcript
+# fails (no log dir, locked file, etc.) the RMM still captures something useful.
+Write-Host "msft-windows-rds-logon-report.ps1 starting"
 Write-Host "Description: $Description"
-Write-Host "Log path: $LogPath"
 Write-Host "RMM: $RMM"
 Write-Host "DaysBack: $DaysBack"
 Write-Host "OutputFolder: $OutputFolder"
+Write-Host "Computer: $env:COMPUTERNAME"
+Write-Host "User context: $env:USERNAME"
+Write-Host "PowerShell: $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+
+# Pre-create the transcript directory so Start-Transcript can't fail on a missing folder.
+$logDir = Split-Path -Path $LogPath -Parent
+if ($logDir -and -not (Test-Path -Path $logDir)) {
+    try {
+        New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+        Write-Host "Created log directory: $logDir"
+    } catch {
+        Write-Host "Warning: could not create log directory ${logDir}: $($_.Exception.Message)"
+    }
+}
+
+# Start the script logic here. Wrap Start-Transcript so a transcript failure
+# (e.g. ErrorActionPreference=Stop in the RMM runner) cannot kill the script.
+$transcriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop | Out-Null
+    $transcriptStarted = $true
+    Write-Host "Transcript started: $LogPath"
+} catch {
+    Write-Host "Warning: Start-Transcript failed for ${LogPath}: $($_.Exception.Message)"
+    Write-Host "Continuing without transcript."
+}
+
+Write-Host "Log path: $LogPath"
 
 # Ensure output folder exists.
 if (-not (Test-Path -Path $OutputFolder)) {
     Write-Host "Creating output folder $OutputFolder"
-    New-Item -Path $OutputFolder -ItemType Directory -Force | Out-Null
+    try {
+        New-Item -Path $OutputFolder -ItemType Directory -Force | Out-Null
+    } catch {
+        Write-Host "ERROR: could not create output folder ${OutputFolder}: $($_.Exception.Message)"
+        if ($transcriptStarted) { Stop-Transcript }
+        exit 1
+    }
 }
 
 $computerName = $env:COMPUTERNAME
@@ -57,13 +90,23 @@ $startTime    = (Get-Date).AddDays(-[int]$DaysBack)
 $timestamp    = Get-Date -Format "yyyyMMdd-HHmmss"
 $csvPath      = Join-Path $OutputFolder ("rds-logons-{0}-{1}days-{2}.csv" -f $computerName, $DaysBack, $timestamp)
 
+# Fail fast if the LSM log is missing/disabled (e.g. running on a non-RDS host).
+$lsmLogName = 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'
+$lsmLog = Get-WinEvent -ListLog $lsmLogName -ErrorAction SilentlyContinue
+if (-not $lsmLog) {
+    Write-Host "ERROR: Event log '$lsmLogName' not present on $computerName. Is RDS Session Host installed?"
+    if ($transcriptStarted) { Stop-Transcript }
+    exit 1
+}
+Write-Host "LSM log: enabled=$($lsmLog.IsEnabled) records=$($lsmLog.RecordCount) sizeBytes=$($lsmLog.FileSize)"
+
 Write-Host "Querying RDS logon events since $startTime on $computerName"
 
 # Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
 #   21 = Remote Desktop Services: Session logon succeeded
 #   25 = Remote Desktop Services: Session reconnection succeeded
 $filter = @{
-    LogName   = 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'
+    LogName   = $lsmLogName
     Id        = 21, 25
     StartTime = $startTime
 }
@@ -76,7 +119,7 @@ try {
         $events = @()
     } else {
         Write-Host "Failed to query event log: $($_.Exception.Message)"
-        Stop-Transcript
+        if ($transcriptStarted) { Stop-Transcript }
         exit 1
     }
 }
@@ -105,9 +148,9 @@ $results = foreach ($event in $events) {
     }
 }
 
-$results = $results | Sort-Object TimeCreated -Descending
+$results = @($results | Sort-Object TimeCreated -Descending)
 
-if ($results) {
+if ($results.Count -gt 0) {
     $results | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-Host "Wrote $($results.Count) rows to $csvPath"
 } else {
@@ -126,4 +169,5 @@ if ($results) {
     Write-Host "No events to export. Empty CSV written to $csvPath"
 }
 
-Stop-Transcript
+Write-Host "msft-windows-rds-logon-report.ps1 completed"
+if ($transcriptStarted) { Stop-Transcript }

--- a/msft-windows/msft-windows-rds-logon-report.ps1
+++ b/msft-windows/msft-windows-rds-logon-report.ps1
@@ -105,61 +105,92 @@ $now          = Get-Date
 $startTime    = $now.AddDays(-[int]$DaysBack)
 $timestamp    = $now.ToString("yyyyMMdd-HHmmss")
 
-# Fail fast if the LSM log is missing/disabled (e.g. running on a non-RDS host).
-$lsmLogName = 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'
-$lsmLog = Get-WinEvent -ListLog $lsmLogName -ErrorAction SilentlyContinue
-if (-not $lsmLog) {
-    Write-Host "ERROR: Event log '$lsmLogName' not present on $computerName. Is RDS Session Host installed?"
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 1
+$securityLogName = 'Security'
+# -ListLog needs admin / Event Log Readers; if that fails it is not a hard error,
+# the real test is the FilterXPath query below.
+$securityLog = Get-WinEvent -ListLog $securityLogName -ErrorAction SilentlyContinue
+if ($securityLog) {
+    Write-Host "Security log: enabled=$($securityLog.IsEnabled) records=$($securityLog.RecordCount) sizeBytes=$($securityLog.FileSize)"
+} else {
+    Write-Host "Note: could not enumerate '$securityLogName' (likely permissions). Continuing to query."
 }
-Write-Host "LSM log: enabled=$($lsmLog.IsEnabled) records=$($lsmLog.RecordCount) sizeBytes=$($lsmLog.FileSize)"
 
 Write-Host "Querying RDS logon events since $startTime on $computerName"
 
-# Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
-#   21 = Remote Desktop Services: Session logon succeeded
-#   25 = Remote Desktop Services: Session reconnection succeeded
-$filter = @{
-    LogName   = $lsmLogName
-    Id        = 21, 25
-    StartTime = $startTime
+# Security log:
+#   4624 LogonType=10 = RemoteInteractive (RDP authentication succeeded)
+#   4778               = Session was reconnected to a Window Station
+# Push filters down to the event log API via XPath so we don't drag the
+# entire Security log into memory on busy hosts.
+$startIso  = $startTime.ToUniversalTime().ToString('o')
+$xpath4624 = "*[System[EventID=4624 and TimeCreated[@SystemTime>='$startIso']]] and *[EventData[Data[@Name='LogonType']='10']]"
+$xpath4778 = "*[System[EventID=4778 and TimeCreated[@SystemTime>='$startIso']]]"
+
+function Get-FilteredEvents {
+    param([string]$LogName, [string]$XPath, [string]$Label)
+    try {
+        return @(Get-WinEvent -LogName $LogName -FilterXPath $XPath -ErrorAction Stop)
+    } catch {
+        if ($_.Exception.Message -match 'No events were found') {
+            Write-Host "No $Label events in window."
+            return @()
+        }
+        throw
+    }
 }
 
 try {
-    $events = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop
+    $logonEvents     = Get-FilteredEvents -LogName $securityLogName -XPath $xpath4624 -Label '4624 (LogonType=10)'
+    $reconnectEvents = Get-FilteredEvents -LogName $securityLogName -XPath $xpath4778 -Label '4778 (reconnect)'
 } catch {
-    if ($_.Exception.Message -match 'No events were found') {
-        Write-Host "No RDS logon events found in the last $DaysBack days."
-        $events = @()
-    } else {
-        Write-Host "Failed to query event log: $($_.Exception.Message)"
-        if ($transcriptStarted) { Stop-Transcript }
-        exit 1
+    $msg = $_.Exception.Message
+    Write-Host "Failed to query Security log: $msg"
+    if ($msg -match 'Attempted to perform an unauthorized operation|access is denied') {
+        Write-Host "Hint: reading the Security log requires Administrator or membership in the 'Event Log Readers' group. NinjaOne running as SYSTEM has access."
     }
+    if ($transcriptStarted) { Stop-Transcript }
+    exit 1
 }
 
-Write-Host "Found $($events.Count) events. Parsing..."
+$events = @($logonEvents) + @($reconnectEvents)
+Write-Host "Found $($logonEvents.Count) logon (4624 LT=10) and $($reconnectEvents.Count) reconnect (4778) events. Parsing..."
 
 $results = foreach ($event in $events) {
-    # The LSM events store User / SessionID / Address inside UserData/EventXML.
+    # Both 4624 and 4778 store fields in EventData/Data nodes keyed by Name attribute.
     $xml = [xml]$event.ToXml()
-    $data = $xml.Event.UserData.EventXML
-
-    $eventType = switch ($event.Id) {
-        21 { 'Logon' }
-        25 { 'Reconnect' }
-        default { "Id$($event.Id)" }
+    $dataNodes = @{}
+    foreach ($d in $xml.Event.EventData.Data) {
+        if ($d.Name) { $dataNodes[$d.Name] = $d.'#text' }
     }
+
+    if ($event.Id -eq 4624) {
+        $eventType = 'Logon'
+        $domain    = $dataNodes['TargetDomainName']
+        $userName  = $dataNodes['TargetUserName']
+        $sessionId = $dataNodes['LogonId']
+        $sourceIp  = $dataNodes['IpAddress']
+    } else {
+        $eventType = 'Reconnect'
+        $domain    = $dataNodes['AccountDomain']
+        $userName  = $dataNodes['AccountName']
+        $sessionId = $dataNodes['SessionName']
+        $sourceIp  = $dataNodes['ClientAddress']
+    }
+
+    # Skip machine accounts and well-known system principals.
+    if ($userName -match '\$$') { continue }
+    if ($userName -in @('SYSTEM', 'ANONYMOUS LOGON', 'LOCAL SERVICE', 'NETWORK SERVICE', 'DWM-1', 'UMFD-0', 'UMFD-1')) { continue }
+
+    $userField = if ($domain) { "$domain\$userName" } else { $userName }
 
     [pscustomobject]@{
         TimeCreated = $event.TimeCreated
         Computer    = $computerName
         EventId     = $event.Id
         EventType   = $eventType
-        User        = $data.User
-        SessionID   = $data.SessionID
-        SourceIP    = $data.Address
+        User        = $userField
+        SessionID   = $sessionId
+        SourceIP    = $sourceIp
     }
 }
 


### PR DESCRIPTION
## Summary
- New script `msft-windows/msft-windows-rds-logon-report.ps1` exporting a CSV of RDP logons over the last 90 days (configurable via `$DaysBack`).
- Source: **Security** event log
  - **Event 4624 with `LogonType=10`** (RemoteInteractive) -> `Logon`
  - **Event 4778** (session reconnected to a Window Station) -> `Reconnect`
- `FilterXPath` pushes both filters into the event log API so the whole Security log is not pulled into memory on busy hosts.
- 4624 vs 4778 field-name differences normalized into the same CSV columns: `TimeCreated, Computer, EventId, EventType, User, SessionID, SourceIP`.
- Machine accounts (trailing `$`) and well-known system principals (SYSTEM, ANONYMOUS LOGON, etc.) filtered out.
- Output: `C:\temp\rds-logons-<computer>-<actualDays>days-<timestamp>.csv` by default. Folder auto-created if missing.
- Filename uses the **actual** data span retrieved, not the requested `$DaysBack` (e.g. requesting 90 days against a host with only 14 days of Security log retention writes `...-14days-...csv`). Empty results write `0days`.

## RMM Variables
- `$DaysBack` (default `90`)
- `$OutputFolder` (default `C:\temp`)
- `$Description` (audit string passed by the RMM)

## RMM hardening (NinjaOne / SYSTEM execution)
- **Auto-detects `-NonInteractive` PowerShell** and forces `$RMM=1` in that case, so operators don't need to add a custom `$RMM=1` variable in NinjaOne. Without this, `Read-Host` in the interactive branch threw `Read and Prompt functionality is not available` and the job failed silently with no transcript and no stdout.
- Fixed inverted `$RMMScriptPath` fallback inherited from the template (NinjaOne does not set `$RMMScriptPath`, which previously pointed `Start-Transcript` at a bogus `\logs\...` path).
- `Start-Transcript` wrapped in try/catch so a transcript failure (e.g. `$ErrorActionPreference=Stop` upstream) cannot kill the script.
- Context (computer, user, PS version + bitness, all variables) printed to stdout **before** transcripting so the RMM job log always captures something even when transcript writing fails.
- Pre-creates both the transcript directory and the output folder.
- Soft check on the Security log via `-ListLog` (informational only, since `-ListLog` requires admin / Event Log Readers); the XPath query is the real permission test. A failure prints a clear hint pointing operators at SYSTEM context or Event Log Readers membership.

## Test plan
- [ ] Run interactively (elevated) on an RDS Session Host with default args; confirm CSV appears in `C:\temp` with logon/reconnect rows
- [ ] Run from NinjaOne as SYSTEM (no `$RMM` variable defined); confirm the auto-detect path fires and the job completes with both stdout and a CSV artifact
- [ ] Spot-check a row: timestamp, `User` (DOMAIN\name), `SourceIP`, and `EventType` match Event Viewer for the same event
- [ ] Run on a host with no qualifying events in the window; confirm an empty header-only CSV is written with `0days` in the filename and the script exits cleanly
- [ ] Run with `$DaysBack=90` on a host where Security retention is shorter; confirm filename reflects the actual span (e.g. `...-23days-...csv`)

## Notes
- Run on the RDS Session Host directly. Security log is per-host.
- Reading the Security log requires Administrator or membership in the **Event Log Readers** group. NinjaOne running as SYSTEM has access by default.
- Earlier iterations of this PR sourced from `Microsoft-Windows-TerminalServices-LocalSessionManager/Operational` (events 21 / 25). LSM defaults to ~1 MB retention which truncated 90-day reports to a couple of weeks of data; the Security log keeps tens of MB by default on servers and is the more authoritative source for RDP authentication.
