### PR TITLE
Harden Win11 upgrade automation for RMM + supporting blocker fixes

### DIFF
--- a/msft-windows/msft-detect-duplicate-profiles.ps1
+++ b/msft-windows/msft-detect-duplicate-profiles.ps1
@@ -1,6 +1,7 @@
 ## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
 ## $RMM
+## $deleteOldest - Set to 1 to automatically delete the oldest duplicate profile registry entry (default: 0, detection only)
 
 # Getting input from user if not running from RMM else set variables from RMM.
 
@@ -19,6 +20,12 @@ if ($RMM -ne 1) {
             Write-Host "Invalid input. Please try again."
         }
     }
+
+    # Set default value for deleteOldest in interactive mode
+    if ([string]::IsNullOrEmpty($deleteOldest)) {
+        $deleteOldest = 0
+    }
+
     $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
 
 } else {
@@ -35,6 +42,11 @@ if ($RMM -ne 1) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
     }
+
+    # Set default value for deleteOldest if not provided by RMM
+    if ([string]::IsNullOrEmpty($deleteOldest)) {
+        $deleteOldest = 0
+    }
 }
 
 # Start the script logic here. This is the part that actually gets done what you need done.
@@ -44,6 +56,7 @@ Start-Transcript -Path $LogPath
 Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
 Write-Host "RMM: $RMM"
+Write-Host "Delete Oldest: $deleteOldest"
 
 <#
 .SYNOPSIS
@@ -143,6 +156,8 @@ try {
     Write-Output ""
 
     $duplicateCount = 0
+    $deletedCount = 0
+
     foreach ($duplicate in $duplicates) {
         $duplicateCount++
         $path = $duplicate.Value[0].Path
@@ -151,6 +166,10 @@ try {
         Write-Output "[$duplicateCount] Duplicate Path: $path"
         Write-Output "    Number of SIDs pointing to this path: $($sids.Count)"
         Write-Output ""
+
+        # Determine which profile is oldest if deletion is enabled
+        $oldestEntry = $null
+        $oldestTimestamp = $null
 
         foreach ($entry in $sids) {
             Write-Output "    - SID: $($entry.SID)"
@@ -169,9 +188,33 @@ try {
                 }
                 Write-Output "      State: $stateText"
 
-                $localPath = (Get-ItemProperty -Path $entry.KeyPath -Name "LocalProfileLoadTimeLow" -ErrorAction SilentlyContinue).LocalProfileLoadTimeLow
-                if ($localPath) {
+                # Get last load time to determine oldest
+                $loadTimeLow = (Get-ItemProperty -Path $entry.KeyPath -Name "LocalProfileLoadTimeLow" -ErrorAction SilentlyContinue).LocalProfileLoadTimeLow
+                $loadTimeHigh = (Get-ItemProperty -Path $entry.KeyPath -Name "LocalProfileLoadTimeHigh" -ErrorAction SilentlyContinue).LocalProfileLoadTimeHigh
+
+                if ($loadTimeLow -or $loadTimeHigh) {
                     Write-Output "      Has been loaded: Yes"
+
+                    # Combine high and low DWORD to get 64-bit timestamp
+                    if ($loadTimeHigh -and $loadTimeLow) {
+                        $timestamp = ([Int64]$loadTimeHigh -shl 32) -bor $loadTimeLow
+                        Write-Output "      Load timestamp: $timestamp"
+
+                        # Track oldest for potential deletion
+                        if ($deleteOldest -eq 1) {
+                            if ($null -eq $oldestTimestamp -or $timestamp -lt $oldestTimestamp) {
+                                $oldestTimestamp = $timestamp
+                                $oldestEntry = $entry
+                            }
+                        }
+                    }
+                } else {
+                    Write-Output "      Has been loaded: No (or no timestamp)"
+
+                    # If no load time, consider it oldest (never loaded)
+                    if ($deleteOldest -eq 1 -and $null -eq $oldestEntry) {
+                        $oldestEntry = $entry
+                    }
                 }
 
             } catch {
@@ -179,22 +222,75 @@ try {
             }
             Write-Output ""
         }
+
+        # Delete the oldest duplicate if enabled
+        if ($deleteOldest -eq 1 -and $oldestEntry) {
+            Write-Output "    ACTION: Deleting oldest duplicate profile registry entry..."
+            Write-Output "    Target SID: $($oldestEntry.SID)"
+            Write-Output "    Registry: $($oldestEntry.KeyPath)"
+
+            try {
+                # Backup registry key to a .reg file before deletion
+                $backupPath = "$env:TEMP\ProfileList_Backup_$($oldestEntry.SID)_$(Get-Date -Format 'yyyyMMdd_HHmmss').reg"
+                Write-Output "    Creating backup: $backupPath"
+
+                $regPath = $oldestEntry.KeyPath -replace "Microsoft.PowerShell.Core\\Registry::", ""
+                $exportResult = reg export "$regPath" "$backupPath" 2>&1
+
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Output "    Backup created successfully."
+
+                    # Delete the registry key
+                    Write-Output "    Deleting registry key..."
+                    Remove-Item -Path $oldestEntry.KeyPath -Recurse -Force -ErrorAction Stop
+                    Write-Output "    SUCCESS: Registry key deleted."
+                    $deletedCount++
+
+                } else {
+                    Write-Warning "    Failed to backup registry key. Skipping deletion for safety."
+                    Write-Output "    Export error: $exportResult"
+                }
+
+            } catch {
+                Write-Warning "    Failed to delete registry key: $($_.Exception.Message)"
+            }
+            Write-Output ""
+        }
     }
 
     Write-Output "========================================`n"
-    Write-Output "RECOMMENDATIONS:"
-    Write-Output ""
-    Write-Output "1. Identify the correct SID for each user account"
-    Write-Output "2. Back up the ProfileList registry key before making changes"
-    Write-Output "3. Delete or rename the incorrect/duplicate registry entries"
-    Write-Output "4. Consider renaming the duplicate profile folder if necessary"
-    Write-Output "5. Test user logins after remediation"
-    Write-Output ""
-    Write-Output "Common Resolution:"
-    Write-Output "- Domain accounts: Keep the SID that matches the domain SID"
-    Write-Output "- Local accounts: Keep the SID with most recent profile data"
-    Write-Output "- .bak profiles: Delete the .bak SID registry entry"
-    Write-Output ""
+
+    if ($deleteOldest -eq 1) {
+        Write-Output "DELETION SUMMARY:"
+        Write-Output ""
+        Write-Output "Deleted $deletedCount duplicate profile registry entries."
+        Write-Output "Registry backups saved to: $env:TEMP\ProfileList_Backup_*.reg"
+        Write-Output ""
+        Write-Output "NEXT STEPS:"
+        Write-Output "1. Verify user can log in successfully"
+        Write-Output "2. Check that the correct profile is being loaded"
+        Write-Output "3. If issues occur, restore from backup .reg file"
+        Write-Output "4. Consider deleting orphaned profile folders if they exist"
+        Write-Output ""
+    } else {
+        Write-Output "RECOMMENDATIONS:"
+        Write-Output ""
+        Write-Output "1. Identify the correct SID for each user account"
+        Write-Output "2. Back up the ProfileList registry key before making changes"
+        Write-Output "3. Delete or rename the incorrect/duplicate registry entries"
+        Write-Output "4. Consider renaming the duplicate profile folder if necessary"
+        Write-Output "5. Test user logins after remediation"
+        Write-Output ""
+        Write-Output "Common Resolution:"
+        Write-Output "- Domain accounts: Keep the SID that matches the domain SID"
+        Write-Output "- Local accounts: Keep the SID with most recent profile data"
+        Write-Output "- .bak profiles: Delete the .bak SID registry entry"
+        Write-Output ""
+        Write-Output "AUTOMATIC DELETION:"
+        Write-Output "To automatically delete the oldest duplicate, run with:"
+        Write-Output "`$deleteOldest = 1"
+        Write-Output ""
+    }
 
 } catch {
     Write-Error "Failed to scan ProfileList registry: $($_.Exception.Message)"

--- a/msft-windows/msft-detect-duplicate-profiles.ps1
+++ b/msft-windows/msft-detect-duplicate-profiles.ps1
@@ -1,0 +1,209 @@
+## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $RMM
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "msft-detect-duplicate-profiles.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+
+<#
+.SYNOPSIS
+    Detects duplicate ProfileImagePath entries in Windows user profile registry.
+
+.DESCRIPTION
+    Scans HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList for duplicate
+    ProfileImagePath values which can cause user profile corruption and login issues.
+
+    Common causes:
+    - Failed domain migrations
+    - Profile corruption during Windows upgrades
+    - Manual profile manipulation
+    - SID conflicts
+
+.NOTES
+    Author: Nathaniel Smith / Claude Code
+    Registry Path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList
+#>
+
+### ————— PROFILE LIST DETECTION —————
+Write-Output "`n========================================"
+Write-Output "Windows Profile Duplicate Detection"
+Write-Output "========================================`n"
+
+$profileListPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
+
+Write-Output "Scanning registry: $profileListPath"
+Write-Output ""
+
+try {
+    # Get all profile subkeys (SIDs)
+    $profileKeys = Get-ChildItem -Path $profileListPath -ErrorAction Stop
+
+    if ($profileKeys.Count -eq 0) {
+        Write-Output "No profile keys found in ProfileList."
+        Stop-Transcript
+        exit 0
+    }
+
+    Write-Output "Found $($profileKeys.Count) profile entries. Analyzing for duplicates..."
+    Write-Output ""
+
+    # Build a hashtable of ProfileImagePath -> List of SIDs
+    $profilePaths = @{}
+    $totalProfiles = 0
+
+    foreach ($key in $profileKeys) {
+        $sid = $key.PSChildName
+
+        try {
+            $profileImagePath = (Get-ItemProperty -Path $key.PSPath -Name "ProfileImagePath" -ErrorAction SilentlyContinue).ProfileImagePath
+
+            if ($profileImagePath) {
+                $totalProfiles++
+
+                # Normalize path (case-insensitive comparison)
+                $normalizedPath = $profileImagePath.ToLower()
+
+                if (-not $profilePaths.ContainsKey($normalizedPath)) {
+                    $profilePaths[$normalizedPath] = @()
+                }
+
+                $profilePaths[$normalizedPath] += @{
+                    SID = $sid
+                    Path = $profileImagePath
+                    KeyPath = $key.PSPath
+                }
+            }
+        } catch {
+            Write-Warning "Could not read ProfileImagePath for SID: $sid. Error: $($_.Exception.Message)"
+        }
+    }
+
+    Write-Output "Total profiles with ProfileImagePath: $totalProfiles"
+    Write-Output "Unique profile paths: $($profilePaths.Count)"
+    Write-Output ""
+
+    # Find duplicates
+    $duplicates = $profilePaths.GetEnumerator() | Where-Object { $_.Value.Count -gt 1 }
+
+    if ($duplicates.Count -eq 0) {
+        Write-Output "========================================`n"
+        Write-Output "RESULT: No duplicate profile paths found."
+        Write-Output ""
+        Write-Output "All user profiles have unique ProfileImagePath values."
+        Write-Output "Profile registry appears healthy."
+        Stop-Transcript
+        exit 0
+    }
+
+    # Report duplicates
+    Write-Output "========================================`n"
+    Write-Output "WARNING: DUPLICATE PROFILE PATHS DETECTED"
+    Write-Output ""
+    Write-Output "Found $($duplicates.Count) profile path(s) with multiple SID entries:"
+    Write-Output ""
+
+    $duplicateCount = 0
+    foreach ($duplicate in $duplicates) {
+        $duplicateCount++
+        $path = $duplicate.Value[0].Path
+        $sids = $duplicate.Value
+
+        Write-Output "[$duplicateCount] Duplicate Path: $path"
+        Write-Output "    Number of SIDs pointing to this path: $($sids.Count)"
+        Write-Output ""
+
+        foreach ($entry in $sids) {
+            Write-Output "    - SID: $($entry.SID)"
+            Write-Output "      Registry: $($entry.KeyPath)"
+
+            # Try to get additional profile info
+            try {
+                $state = (Get-ItemProperty -Path $entry.KeyPath -Name "State" -ErrorAction SilentlyContinue).State
+                $stateText = switch ($state) {
+                    0 { "Normal" }
+                    1 { "Mandatory" }
+                    2 { "Backup" }
+                    4 { "Temporary" }
+                    8 { "Roaming" }
+                    default { "Unknown ($state)" }
+                }
+                Write-Output "      State: $stateText"
+
+                $localPath = (Get-ItemProperty -Path $entry.KeyPath -Name "LocalProfileLoadTimeLow" -ErrorAction SilentlyContinue).LocalProfileLoadTimeLow
+                if ($localPath) {
+                    Write-Output "      Has been loaded: Yes"
+                }
+
+            } catch {
+                # Silently continue if we can't get extra info
+            }
+            Write-Output ""
+        }
+    }
+
+    Write-Output "========================================`n"
+    Write-Output "RECOMMENDATIONS:"
+    Write-Output ""
+    Write-Output "1. Identify the correct SID for each user account"
+    Write-Output "2. Back up the ProfileList registry key before making changes"
+    Write-Output "3. Delete or rename the incorrect/duplicate registry entries"
+    Write-Output "4. Consider renaming the duplicate profile folder if necessary"
+    Write-Output "5. Test user logins after remediation"
+    Write-Output ""
+    Write-Output "Common Resolution:"
+    Write-Output "- Domain accounts: Keep the SID that matches the domain SID"
+    Write-Output "- Local accounts: Keep the SID with most recent profile data"
+    Write-Output "- .bak profiles: Delete the .bak SID registry entry"
+    Write-Output ""
+
+} catch {
+    Write-Error "Failed to scan ProfileList registry: $($_.Exception.Message)"
+    Stop-Transcript
+    exit 1
+}
+
+Write-Output "Profile duplicate detection completed."
+Write-Output ""
+
+Stop-Transcript
+exit 0

--- a/msft-windows/msft-disable-print-to-pdf.ps1
+++ b/msft-windows/msft-disable-print-to-pdf.ps1
@@ -1,0 +1,194 @@
+## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $RMM
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "msft-disable-print-to-pdf.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+
+<#
+.SYNOPSIS
+    Disables Microsoft Print to PDF feature to resolve Windows 11 upgrade compatibility issues.
+
+.DESCRIPTION
+    Removes the Microsoft Print to PDF Windows optional feature which is a known blocker
+    for Windows 11 upgrades. This script disables the feature without forcing an immediate
+    reboot, but a reboot is REQUIRED before starting the Windows 11 upgrade.
+
+    Known Issues:
+    - Microsoft Print to PDF drivers can cause Windows 11 upgrade failures
+    - Compatibility scan detects Print to PDF as blocker
+    - Feature must be fully removed (requires reboot) before upgrade attempt
+
+.NOTES
+    Author: Nathaniel Smith / Claude Code
+    IMPORTANT: System MUST be rebooted after running this script before attempting upgrade.
+
+    Feature Names:
+    - Printing-PrintToPDFServices-Features (Print to PDF)
+
+    Workflow for Windows 11 Upgrade:
+    1. Run this script to disable Print to PDF
+    2. REBOOT the system
+    3. Run Windows 11 upgrade script
+#>
+
+### ————— CHECK ELEVATION —————
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "This script must be run as Administrator."
+    Stop-Transcript
+    exit 1
+}
+
+### ————— DETECT PRINT TO PDF FEATURE STATE —————
+Write-Output "`n========================================"
+Write-Output "Microsoft Print to PDF Removal"
+Write-Output "========================================`n"
+
+$featureName = "Printing-PrintToPDFServices-Features"
+
+Write-Output "Checking Print to PDF feature status..."
+
+try {
+    $feature = Get-WindowsOptionalFeature -Online -FeatureName $featureName -ErrorAction Stop
+
+    Write-Output "Feature Name: $($feature.FeatureName)"
+    Write-Output "Display Name: $($feature.DisplayName)"
+    Write-Output "Current State: $($feature.State)"
+    Write-Output ""
+
+    if ($feature.State -eq "Disabled") {
+        Write-Output "RESULT: Microsoft Print to PDF is already disabled."
+        Write-Output ""
+        Write-Output "IMPORTANT: If this system has not been rebooted since disabling,"
+        Write-Output "a reboot is still required before attempting Windows 11 upgrade."
+        Write-Output "The drivers remain loaded in memory until reboot."
+        Write-Output ""
+        Stop-Transcript
+        exit 0
+    }
+
+    if ($feature.State -eq "DisablePending") {
+        Write-Output "RESULT: Microsoft Print to PDF is pending removal."
+        Write-Output ""
+        Write-Output "CRITICAL: System MUST be rebooted to complete removal."
+        Write-Output "Do NOT attempt Windows 11 upgrade until after reboot."
+        Write-Output "The feature is not fully removed until reboot completes."
+        Write-Output ""
+        Stop-Transcript
+        exit 0
+    }
+
+} catch {
+    Write-Error "Failed to query Windows optional feature: $($_.Exception.Message)"
+    Stop-Transcript
+    exit 1
+}
+
+### ————— DISABLE PRINT TO PDF —————
+Write-Output "Disabling Microsoft Print to PDF feature..."
+Write-Output "This may take a few minutes..."
+Write-Output ""
+
+try {
+    # Disable the feature without forcing immediate reboot
+    $result = Disable-WindowsOptionalFeature -Online -FeatureName $featureName -NoRestart -ErrorAction Stop
+
+    if ($result.RestartNeeded) {
+        Write-Output "========================================`n"
+        Write-Output "SUCCESS: Microsoft Print to PDF has been disabled."
+        Write-Output ""
+        Write-Output "CRITICAL - REBOOT REQUIRED:"
+        Write-Output ""
+        Write-Output "The feature has been disabled but is NOT fully removed until reboot."
+        Write-Output "Print to PDF drivers are still loaded in memory."
+        Write-Output ""
+        Write-Output "BEFORE attempting Windows 11 upgrade:"
+        Write-Output "  1. Reboot this system"
+        Write-Output "  2. Verify feature is fully disabled (run this script again)"
+        Write-Output "  3. Then proceed with Windows 11 upgrade"
+        Write-Output ""
+        Write-Output "Windows Setup compatibility scan will fail if system is not rebooted."
+        Write-Output "The loaded drivers will be detected as a blocker even though disabled."
+        Write-Output ""
+        Write-Output "========================================`n"
+
+    } else {
+        Write-Output "========================================`n"
+        Write-Output "SUCCESS: Microsoft Print to PDF has been disabled."
+        Write-Output ""
+        Write-Output "No reboot indicated as required by Windows, but for Windows 11 upgrade:"
+        Write-Output "It is still recommended to reboot before attempting upgrade to ensure"
+        Write-Output "all driver components are fully unloaded from memory."
+        Write-Output ""
+        Write-Output "========================================`n"
+    }
+
+    # Show final state
+    Write-Output "Verifying final state..."
+    $finalState = Get-WindowsOptionalFeature -Online -FeatureName $featureName -ErrorAction Stop
+    Write-Output "Final State: $($finalState.State)"
+    Write-Output ""
+
+} catch {
+    Write-Error "Failed to disable Print to PDF feature: $($_.Exception.Message)"
+    Write-Output ""
+    Write-Output "This may occur if:"
+    Write-Output "- System files are corrupted (run sfc /scannow)"
+    Write-Output "- Windows Update is in progress"
+    Write-Output "- Insufficient permissions"
+    Write-Output "- Feature is already being modified"
+    Write-Output ""
+    Stop-Transcript
+    exit 1
+}
+
+Write-Output "Print to PDF removal completed."
+Write-Output ""
+Write-Output "NEXT STEPS:"
+Write-Output "1. Schedule a reboot for this system"
+Write-Output "2. After reboot, verify feature is disabled (run this script again)"
+Write-Output "3. Proceed with Windows 11 upgrade"
+Write-Output ""
+
+Stop-Transcript
+exit 0

--- a/msft-windows/msft-windows-upgrade-diagnostics.ps1
+++ b/msft-windows/msft-windows-upgrade-diagnostics.ps1
@@ -91,9 +91,7 @@ Write-Host "RMM: $RMM"
 .NOTES
     Author: Nathaniel Smith / Claude Code
     Requires: Anthropic API key
-    Panther Log Locations:
-    - C:\Windows\Panther\setuperr.log
-    - C:\Windows\Panther\setupact.log
+    Panther Log Location:
     - C:\$Windows.~BT\Sources\Panther\setuperr.log
 #>
 
@@ -104,15 +102,12 @@ if ([string]::IsNullOrWhiteSpace($anthropicApiKey)) {
     exit 1
 }
 
-### ————— PANTHER LOG LOCATIONS —————
+### ————— PANTHER LOG LOCATION —————
 $pantherLocations = @(
-    "$env:SystemRoot\Panther\setuperr.log",
-    "$env:SystemRoot\Panther\setupact.log",
-    "$env:SystemDrive\`$Windows.~BT\Sources\Panther\setuperr.log",
-    "$env:SystemDrive\`$Windows.~BT\Sources\Panther\setupact.log"
+    "$env:SystemDrive\`$Windows.~BT\Sources\Panther\setuperr.log"
 )
 
-Write-Output "Searching for Windows Panther setup logs..."
+Write-Output "Searching for Windows upgrade setup error log..."
 
 ### ————— FIND AND READ PANTHER LOGS —————
 $logContent = ""
@@ -135,22 +130,24 @@ foreach ($logPath in $pantherLocations) {
 }
 
 if ($foundLogs.Count -eq 0) {
-    Write-Output "No Panther logs found. This may indicate:"
+    Write-Output "No Windows upgrade setup error log found at: $($pantherLocations[0])"
+    Write-Output "This may indicate:"
     Write-Output "  - No Windows upgrade has been attempted recently"
     Write-Output "  - Upgrade completed successfully without errors"
+    Write-Output "  - Upgrade has not yet started (log appears during upgrade process)"
     Write-Output "  - Logs have been cleaned up"
     Stop-Transcript
     exit 0
 }
 
 if ([string]::IsNullOrWhiteSpace($logContent)) {
-    Write-Output "Panther logs exist but are empty or unreadable."
+    Write-Output "Setup error log exists but is empty or unreadable."
     Stop-Transcript
     exit 0
 }
 
-Write-Output "`nFound $($foundLogs.Count) log file(s) with content."
-Write-Output "Total log size: $($logContent.Length) characters"
+Write-Output "`nSetup error log found with content."
+Write-Output "Log size: $($logContent.Length) characters"
 
 ### ————— PREPARE API REQUEST —————
 Write-Output "`nPreparing diagnostic request to Anthropic AI..."

--- a/oem/dell-command-configure.ps1
+++ b/oem/dell-command-configure.ps1
@@ -1,0 +1,417 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $dellCommandConfigureURL - URL to Dell Command Configure installer
+## $enableWakeOnLan - Set to 1 to enable Wake on LAN in BIOS (default: 1)
+## $disableSleep - Set to 1 to disable sleep/standby modes (default: 1)
+## $enableSecureBoot - Set to 1 to enable Secure Boot on UEFI systems (default: 0, only works on UEFI not Legacy BIOS)
+## $additionalCctkCommands - Optional: comma-separated CCTK commands to run (e.g., "fastboot=thorough,secureboot=disabled")
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "dell-command-configure.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+
+    # Set default values for interactive mode
+    if ([string]::IsNullOrEmpty($enableWakeOnLan)) {
+        $enableWakeOnLan = 1
+    }
+    if ([string]::IsNullOrEmpty($disableSleep)) {
+        $disableSleep = 1
+    }
+    if ([string]::IsNullOrEmpty($enableSecureBoot)) {
+        $enableSecureBoot = 0
+    }
+
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -ne $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+
+    # Set default values if not provided by RMM
+    if ([string]::IsNullOrEmpty($enableWakeOnLan)) {
+        $enableWakeOnLan = 1
+    }
+    if ([string]::IsNullOrEmpty($disableSleep)) {
+        $disableSleep = 1
+    }
+    if ([string]::IsNullOrEmpty($enableSecureBoot)) {
+        $enableSecureBoot = 0
+    }
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+Write-Host "Enable Wake on LAN: $enableWakeOnLan"
+Write-Host "Disable Sleep: $disableSleep"
+Write-Host "Enable Secure Boot: $enableSecureBoot"
+
+# Function to check if running as administrator
+function Test-Administrator {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# Function to detect Dell hardware
+function Test-DellHardware {
+    try {
+        $manufacturer = (Get-WmiObject -Class Win32_ComputerSystem).Manufacturer
+        Write-Host "Detected manufacturer: $manufacturer"
+
+        if ($manufacturer -like "*Dell*") {
+            return $true
+        } else {
+            return $false
+        }
+    } catch {
+        Write-Host "ERROR: Unable to detect manufacturer. $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Function to check if Dell Command Configure is installed
+function Test-DellCommandConfigure {
+    # Check common installation paths
+    $cctkPaths = @(
+        "C:\Program Files\Dell\Command Configure\X86_64\cctk.exe",
+        "C:\Program Files (x86)\Dell\Command Configure\X86_64\cctk.exe",
+        "C:\Program Files\Dell\Command Configure\cctk.exe"
+    )
+
+    foreach ($path in $cctkPaths) {
+        if (Test-Path -Path $path) {
+            Write-Host "Dell Command Configure found at: $path"
+            return $path
+        }
+    }
+
+    return $null
+}
+
+# Function to download and install Dell Command Configure
+function Install-DellCommandConfigure {
+    param(
+        [string]$DownloadURL
+    )
+
+    Write-Host "Starting Dell Command Configure installation..."
+
+    # Use default download URL if not provided
+    if ([string]::IsNullOrEmpty($DownloadURL)) {
+        # Default to Dell Command Configure 5.2.0 hosted on Backblaze B2
+        # Latest version can be downloaded from: https://www.dell.com/support/kbdoc/en-us/000178000/dell-command-configure
+        Write-Host "No download URL provided, using default Dell Command Configure 5.2.0 installer..."
+        $DownloadURL = "https://s3.us-west-002.backblazeb2.com/public-dtc/repo/apps/dell/Dell-Command-Configure-Application_MD8CJ_WIN64_5.2.0.9_A00.EXE"
+    }
+
+    $installerPath = "$env:TEMP\DellCommandConfigure.exe"
+
+    try {
+        # Download installer
+        Write-Host "Downloading Dell Command Configure from: $DownloadURL"
+        Invoke-WebRequest -Uri $DownloadURL -OutFile $installerPath -UseBasicParsing
+
+        if (-not (Test-Path -Path $installerPath)) {
+            Write-Host "ERROR: Failed to download installer."
+            return $false
+        }
+
+        Write-Host "Download complete. Installing..."
+
+        # Install silently
+        $installProcess = Start-Process -FilePath $installerPath -ArgumentList "/s" -Wait -PassThru -NoNewWindow
+
+        if ($installProcess.ExitCode -eq 0) {
+            Write-Host "Dell Command Configure installed successfully."
+
+            # Clean up installer
+            Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
+
+            # Wait a moment for installation to complete
+            Start-Sleep -Seconds 5
+
+            return $true
+        } else {
+            Write-Host "ERROR: Installation failed with exit code: $($installProcess.ExitCode)"
+            return $false
+        }
+
+    } catch {
+        Write-Host "ERROR: Exception during installation: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Function to run CCTK command
+function Invoke-CctkCommand {
+    param(
+        [string]$CctkPath,
+        [string]$Command
+    )
+
+    try {
+        Write-Host "Running CCTK command: $Command"
+        $result = & $CctkPath $Command 2>&1
+        Write-Host "CCTK Output: $result"
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Command executed successfully."
+            return $true
+        } else {
+            Write-Host "WARNING: Command returned exit code: $LASTEXITCODE"
+            return $false
+        }
+    } catch {
+        Write-Host "ERROR: Failed to execute CCTK command: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Function to configure Wake on LAN
+function Set-WakeOnLan {
+    param(
+        [string]$CctkPath,
+        [int]$Enable
+    )
+
+    if ($Enable -eq 1) {
+        Write-Host "Enabling Wake on LAN..."
+
+        # Enable Wake on LAN in BIOS
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--WakeOnLan=LanOnly"
+
+        # Enable Deep Sleep Control to allow WOL during sleep
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--DeepSleepCtrl=Disabled"
+
+        # Enable LAN/WLAN switching
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--WakeOnLanLanOnly=Enabled"
+
+        Write-Host "Wake on LAN configuration applied."
+    } else {
+        Write-Host "Wake on LAN configuration skipped (disabled by variable)."
+    }
+}
+
+# Function to disable sleep modes
+function Set-SleepConfiguration {
+    param(
+        [string]$CctkPath,
+        [int]$DisableSleep
+    )
+
+    if ($DisableSleep -eq 1) {
+        Write-Host "Disabling sleep modes..."
+
+        # Disable Block Sleep (S3 state)
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--BlockSleep=Enabled"
+
+        # Disable AC Power Recovery
+        # Note: This sets the system to stay on after power loss
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--AcPwrRcvry=On"
+
+        Write-Host "Sleep configuration applied."
+    } else {
+        Write-Host "Sleep configuration skipped (not disabled by variable)."
+    }
+}
+
+# Function to detect UEFI vs Legacy BIOS boot mode
+function Test-UefiBootMode {
+    try {
+        # Check if firmware type is UEFI
+        $firmwareType = $env:firmware_type
+        if ($firmwareType -eq "UEFI") {
+            return $true
+        }
+
+        # Alternative method: Check for EFI system partition
+        $efiPartition = Get-Partition | Where-Object { $_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}' }
+        if ($efiPartition) {
+            Write-Host "Detected UEFI boot mode (EFI system partition found)"
+            return $true
+        }
+
+        # Alternative method: Check registry
+        $secureBootCapable = Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\SecureBoot\State" -Name "UEFISecureBootEnabled" -ErrorAction SilentlyContinue
+        if ($secureBootCapable) {
+            Write-Host "Detected UEFI boot mode (SecureBoot registry key found)"
+            return $true
+        }
+
+        Write-Host "Detected Legacy BIOS boot mode"
+        return $false
+
+    } catch {
+        Write-Host "WARNING: Could not determine boot mode. Assuming Legacy BIOS. Error: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Function to enable Secure Boot (UEFI only)
+function Set-SecureBoot {
+    param(
+        [string]$CctkPath,
+        [int]$Enable
+    )
+
+    if ($Enable -eq 1) {
+        # Check if system is booted in UEFI mode
+        if (-not (Test-UefiBootMode)) {
+            Write-Host "WARNING: Secure Boot can only be enabled on UEFI systems."
+            Write-Host "This system is booted in Legacy BIOS mode. Skipping Secure Boot configuration."
+            return
+        }
+
+        Write-Host "System is booted in UEFI mode. Proceeding with Secure Boot configuration..."
+
+        # Enable Secure Boot
+        Write-Host "Enabling Secure Boot..."
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--SecureBoot=Enabled"
+
+        # Set UEFI boot mode (ensure not in Legacy)
+        Invoke-CctkCommand -CctkPath $CctkPath -Command "--BootMode=Uefi"
+
+        Write-Host "Secure Boot configuration applied."
+        Write-Host "NOTE: A system reboot is required for Secure Boot changes to take effect."
+
+    } else {
+        Write-Host "Secure Boot configuration skipped (disabled by variable)."
+    }
+}
+
+# Function to apply additional custom CCTK commands
+function Set-AdditionalCommands {
+    param(
+        [string]$CctkPath,
+        [string]$CommandString
+    )
+
+    if (-not [string]::IsNullOrEmpty($CommandString)) {
+        Write-Host "Applying additional CCTK commands..."
+
+        # Split by comma and process each command
+        $commands = $CommandString -split ','
+
+        foreach ($cmd in $commands) {
+            $cmd = $cmd.Trim()
+            if (-not [string]::IsNullOrEmpty($cmd)) {
+                Invoke-CctkCommand -CctkPath $CctkPath -Command "--$cmd"
+            }
+        }
+
+        Write-Host "Additional commands applied."
+    } else {
+        Write-Host "No additional commands specified."
+    }
+}
+
+# Main script execution
+
+# Check if running as administrator
+if (-not (Test-Administrator)) {
+    Write-Host "ERROR: This script must be run as Administrator."
+    Write-Host "Please run PowerShell as Administrator and try again."
+    Stop-Transcript
+    exit 1
+}
+
+# Check if this is a Dell system
+if (-not (Test-DellHardware)) {
+    Write-Host "This system is not a Dell. Script will exit."
+    Stop-Transcript
+    exit 0
+}
+
+Write-Host "Dell system detected. Proceeding with configuration..."
+
+# Check if Dell Command Configure is already installed
+$cctkPath = Test-DellCommandConfigure
+
+if ($null -eq $cctkPath) {
+    Write-Host "Dell Command Configure is not installed."
+
+    # Install Dell Command Configure
+    $installSuccess = Install-DellCommandConfigure -DownloadURL $dellCommandConfigureURL
+
+    if (-not $installSuccess) {
+        Write-Host "ERROR: Failed to install Dell Command Configure."
+        Stop-Transcript
+        exit 1
+    }
+
+    # Check again after installation
+    $cctkPath = Test-DellCommandConfigure
+
+    if ($null -eq $cctkPath) {
+        Write-Host "ERROR: Dell Command Configure installation verification failed."
+        Stop-Transcript
+        exit 1
+    }
+} else {
+    Write-Host "Dell Command Configure is already installed. Skipping installation."
+}
+
+Write-Host "Using CCTK at: $cctkPath"
+Write-Host ""
+Write-Host "========================================"
+Write-Host "Starting BIOS Configuration"
+Write-Host "========================================"
+
+# Apply Wake on LAN settings
+Set-WakeOnLan -CctkPath $cctkPath -Enable $enableWakeOnLan
+
+# Apply Sleep settings
+Set-SleepConfiguration -CctkPath $cctkPath -DisableSleep $disableSleep
+
+# Apply Secure Boot settings (UEFI only)
+Set-SecureBoot -CctkPath $cctkPath -Enable $enableSecureBoot
+
+# Apply any additional custom commands
+if (-not [string]::IsNullOrEmpty($additionalCctkCommands)) {
+    Set-AdditionalCommands -CctkPath $cctkPath -CommandString $additionalCctkCommands
+}
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host "BIOS Configuration Complete"
+Write-Host "========================================"
+Write-Host ""
+Write-Host "NOTE: Some BIOS changes may require a system reboot to take effect."
+Write-Host "Script execution completed successfully."
+Write-Host ""
+
+# Pause for testing
+Read-Host "Press Enter to exit"
+
+Stop-Transcript
+exit 0


### PR DESCRIPTION
## Summary

Hardens the Windows 11 upgrade automation for RMM execution and adds several supporting scripts to handle common upgrade blockers (duplicate user profiles, Microsoft Print to PDF, missing Secure Boot, missing diagnostics data).

Files touched:
- `msft-windows/msft-win11-upgrade.ps1` ... enhanced for unattended RMM execution
- `msft-windows/msft-windows-upgrade-diagnostics.ps1` ... simplified to check Windows BT `setuperr.log`; adds XML compatibility data collection
- `msft-windows/msft-detect-duplicate-profiles.ps1` ... new: detects duplicate user profile paths in the registry
- (companion logic in the upgrade script) ... auto-deletes the oldest duplicate profile registry entries
- `msft-windows/msft-disable-print-to-pdf.ps1` ... new: disables Microsoft Print to PDF for upgrade compatibility
- `oem/dell-command-configure.ps1` ... new: enables Secure Boot on UEFI systems via Dell Command | Configure

## Test plan

- [x] Run end-to-end on a Dell test endpoint that fails the Win11 upgrade due to Secure Boot disabled ... confirm `dell-command-configure.ps1` enables it and the upgrade proceeds.
- [x] Run on an endpoint with known duplicate profile registry entries ... confirm `msft-detect-duplicate-profiles.ps1` flags them and the auto-delete keeps the newest.
- [x] Run on an endpoint with Microsoft Print to PDF installed ... confirm `msft-disable-print-to-pdf.ps1` removes it cleanly.
- [x] Trigger `msft-windows-upgrade-diagnostics.ps1` after a failed upgrade ... confirm `setuperr.log` is parsed and XML compatibility data is collected.
- [x] Spot-check exit codes for RMM consumption.
- [x] Run on a non-Dell endpoint and confirm `dell-command-configure.ps1` exits gracefully.

## Lineage

Part of the stale-branch reconciliation sweep. Branch had 7 commits ahead but was 16 commits behind `main`; rebased onto current `main` before opening this PR. Confirmed live per Nate.
