### PR TITLE
feature: HP OEM hybrid pattern (HPIA + BCU + debloat)

### DIFF
--- a/oem-hp/hp-baseline.ps1
+++ b/oem-hp/hp-baseline.ps1
@@ -1,0 +1,199 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:RunHPIAInstall            - "1" to ensure HP Image Assistant is installed (default: "1")
+## $env:RunHPIARun                - "1" to invoke HPIA analyze + install (default: "1")
+## $env:RunHPBiosConfig           - "1" to push BIOS config via BCU (default: "0")
+## $env:RunHPDebloat              - "1" to remove HP consumer software (default: "1")
+## $env:CustomFieldHPStatus       - Ninja text custom field for last-run status (default: "hpBaselineStatus")
+## $env:LibTag                    - jsDelivr tag to fetch leaf scripts and libs from (default: "release")
+
+$ScriptLogName = "hp-baseline.log"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:RunHPIAInstall))    { $env:RunHPIAInstall    = "1" }
+if ([string]::IsNullOrEmpty($env:RunHPIARun))        { $env:RunHPIARun        = "1" }
+if ([string]::IsNullOrEmpty($env:RunHPBiosConfig))   { $env:RunHPBiosConfig   = "0" }
+if ([string]::IsNullOrEmpty($env:RunHPDebloat))      { $env:RunHPDebloat      = "1" }
+if ([string]::IsNullOrEmpty($env:CustomFieldHPStatus)) { $env:CustomFieldHPStatus = "hpBaselineStatus" }
+if ([string]::IsNullOrEmpty($env:LibTag))            { $env:LibTag            = "release" }
+
+# === LIB BOOTSTRAP ===
+# TODO: Replace REPLACE_WITH_REAL_HASH values once the libs land on the @release tag.
+# Capture with: Get-FileHash -Algorithm SHA256 <path-to-lib>
+
+$libs = @(
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-shared/lib/oem-manufacturer-detect.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" },
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/lib/hp-detection.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" }
+)
+foreach ($lib in $libs) {
+    $libPath = Join-Path $env:TEMP ([System.IO.Path]::GetFileName($lib.Url))
+    Invoke-WebRequest -Uri $lib.Url -OutFile $libPath -UseBasicParsing -ErrorAction Stop
+    $actual = (Get-FileHash -Path $libPath -Algorithm SHA256).Hash
+    if ($actual -ne $lib.Sha256) {
+        throw "Lib SHA256 mismatch for $($lib.Url). Expected $($lib.Sha256), got $actual."
+    }
+    . $libPath
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "HP Baseline"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+# Ninja Custom Fields are written via Ninja-Property-Set when the agent CLI is present.
+function Set-NinjaStatus {
+    param([string] $Value)
+    $cli = "$env:ProgramData\NinjaRMMAgent\ninjarmm-cli.exe"
+    if (Test-Path -Path $cli) {
+        try {
+            & $cli set $env:CustomFieldHPStatus $Value | Out-Null
+        } catch {
+            Write-Host "Warning: failed to set Ninja custom field '$($env:CustomFieldHPStatus)': $_"
+        }
+    } else {
+        Write-Host "Ninja CLI not present; status would be: $Value"
+    }
+}
+
+$manufacturer = Get-OEMManufacturer
+Write-Host "Manufacturer: $manufacturer"
+
+if ($manufacturer -ne "HP") {
+    Write-Host "Not an HP endpoint. Exiting."
+    Set-NinjaStatus "Skipped: not HP"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+$hpModel = Get-HPInstalledModel
+Write-Host "HP model: $hpModel"
+
+# Fetch + invoke a leaf script from jsDelivr at the same tag the libs came from.
+# TODO: Replace REPLACE_WITH_REAL_HASH per leaf once the leaves land on @release.
+function Invoke-HPLeaf {
+    param(
+        [Parameter(Mandatory)] [string] $LeafName,
+        [Parameter(Mandatory)] [string] $Sha256
+    )
+    $url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/$LeafName"
+    $local = Join-Path $env:TEMP $LeafName
+    Get-VerifiedDownload -Url $url -OutFile $local -Sha256 $Sha256 | Out-Null
+    & powershell.exe -ExecutionPolicy Bypass -NoProfile -File $local
+    return $LASTEXITCODE
+}
+
+$leafResults = @{}
+$overallStatus = "OK"
+
+if ($env:RunHPIAInstall -eq "1") {
+    Write-Host "`n=== hp-image-assistant-install ==="
+    try {
+        $rc = Invoke-HPLeaf -LeafName "hp-image-assistant-install.ps1" -Sha256 "REPLACE_WITH_REAL_HASH"
+        $leafResults["hpiaInstall"] = $rc
+        if ($rc -ne 0) { $overallStatus = "HPIAInstallFailed" }
+    } catch {
+        Write-Host "hp-image-assistant-install threw: $_"
+        $leafResults["hpiaInstall"] = -1
+        $overallStatus = "HPIAInstallFailed"
+    }
+}
+
+if ($env:RunHPIARun -eq "1" -and $overallStatus -eq "OK") {
+    Write-Host "`n=== hp-image-assistant-run ==="
+    try {
+        $rc = Invoke-HPLeaf -LeafName "hp-image-assistant-run.ps1" -Sha256 "REPLACE_WITH_REAL_HASH"
+        $leafResults["hpiaRun"] = $rc
+        # HPIA exit codes 0 / 256 = OK; 257 / 3010 = reboot required (treat as success).
+        if ($rc -notin 0, 256, 257, 3010) { $overallStatus = "HPIARunFailed" }
+    } catch {
+        Write-Host "hp-image-assistant-run threw: $_"
+        $leafResults["hpiaRun"] = -1
+        $overallStatus = "HPIARunFailed"
+    }
+}
+
+if ($env:RunHPBiosConfig -eq "1") {
+    Write-Host "`n=== hp-bios-config ==="
+    try {
+        $rc = Invoke-HPLeaf -LeafName "hp-bios-config.ps1" -Sha256 "REPLACE_WITH_REAL_HASH"
+        $leafResults["biosConfig"] = $rc
+        if ($rc -ne 0 -and $overallStatus -eq "OK") { $overallStatus = "BiosConfigFailed" }
+    } catch {
+        Write-Host "hp-bios-config threw: $_"
+        $leafResults["biosConfig"] = -1
+        if ($overallStatus -eq "OK") { $overallStatus = "BiosConfigFailed" }
+    }
+}
+
+if ($env:RunHPDebloat -eq "1") {
+    Write-Host "`n=== hp-debloat ==="
+    try {
+        $rc = Invoke-HPLeaf -LeafName "hp-debloat.ps1" -Sha256 "REPLACE_WITH_REAL_HASH"
+        $leafResults["debloat"] = $rc
+        if ($rc -ne 0 -and $overallStatus -eq "OK") { $overallStatus = "DebloatFailed" }
+    } catch {
+        Write-Host "hp-debloat threw: $_"
+        $leafResults["debloat"] = -1
+        if ($overallStatus -eq "OK") { $overallStatus = "DebloatFailed" }
+    }
+}
+
+Write-Host "`n=== Summary ==="
+foreach ($k in $leafResults.Keys) {
+    Write-Host (" {0,-12} exit={1}" -f $k, $leafResults[$k])
+}
+Write-Host "Overall: $overallStatus"
+
+$statusLine = "{0} | {1} | {2}" -f $overallStatus, $hpModel, (Get-Date -Format "yyyy-MM-dd HH:mm")
+Set-NinjaStatus $statusLine
+
+if ($TranscriptStarted) { Stop-Transcript }
+
+if ($overallStatus -eq "OK") { exit 0 } else { exit 1 }

--- a/oem-hp/hp-bios-config.ps1
+++ b/oem-hp/hp-bios-config.ps1
@@ -1,0 +1,136 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:HPBiosPolicyURL           - jsDelivr URL of the .repset policy file to apply
+##                                  (default: dtc-baseline.repset in this repo at $LibTag)
+## $env:HPBiosPolicySha256        - SHA256 of the policy file (TODO: capture and pin)
+## $env:HPBiosAdminPasswordFile   - Optional path to a binary password file produced by
+##                                  HPQPswd64.exe (passed to BCU via /cspwdfile)
+## $env:LibTag                    - jsDelivr tag for shared libs and policy file (default: "release")
+
+$ScriptLogName = "hp-bios-config.log"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:LibTag)) { $env:LibTag = "release" }
+if ([string]::IsNullOrEmpty($env:HPBiosPolicyURL)) {
+    $env:HPBiosPolicyURL = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/policy/dtc-baseline.repset"
+}
+# TODO: Capture SHA256 of the .repset policy file once it lands at the URL above.
+# TODO: Author oem-hp/policy/dtc-baseline.repset by running
+# `BiosConfigUtility64.exe /getconfig:current.repset` on a known-good HP and editing
+# the active values (*-prefixed lines) to the DTC baseline (Secure Boot enabled, WOL
+# disabled, etc.). Commit at that path so the URL above resolves.
+if ([string]::IsNullOrEmpty($env:HPBiosPolicySha256)) {
+    $env:HPBiosPolicySha256 = "REPLACE_WITH_REAL_HASH"
+}
+
+# === LIB BOOTSTRAP ===
+# TODO: Replace REPLACE_WITH_REAL_HASH once libs land on @release.
+
+$libs = @(
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-shared/lib/oem-manufacturer-detect.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" },
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/lib/hp-detection.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" }
+)
+foreach ($lib in $libs) {
+    $libPath = Join-Path $env:TEMP ([System.IO.Path]::GetFileName($lib.Url))
+    Invoke-WebRequest -Uri $lib.Url -OutFile $libPath -UseBasicParsing -ErrorAction Stop
+    $actual = (Get-FileHash -Path $libPath -Algorithm SHA256).Hash
+    if ($actual -ne $lib.Sha256) {
+        throw "Lib SHA256 mismatch for $($lib.Url). Expected $($lib.Sha256), got $actual."
+    }
+    . $libPath
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "HP BIOS Config"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-HPHardware)) {
+    Write-Host "Not an HP endpoint. Exiting."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+$bcu = Get-HPBCUPath
+if (-not $bcu) {
+    Write-Host "BiosConfigUtility64.exe not found. HP BIOS Configuration Utility must be installed before this script can run."
+    Write-Host "Checked: Program Files (x86)\Hewlett-Packard\BIOS Configuration Utility\, Program Files\Hewlett-Packard\BIOS Configuration Utility\, and the HP\BIOS Configuration Utility\ variants."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 2
+}
+
+Write-Host "BCU path: $bcu"
+
+$policyPath = Join-Path $env:TEMP "dtc-hp-baseline.repset"
+try {
+    Get-VerifiedDownload -Url $env:HPBiosPolicyURL -OutFile $policyPath -Sha256 $env:HPBiosPolicySha256 | Out-Null
+} catch {
+    Write-Host "Failed to fetch BIOS policy: $_"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}
+
+$bcuLog = Join-Path $env:TEMP "hp-bcu.log"
+Write-Host "Applying policy: $policyPath"
+
+# Reference: https://ftp.hp.com/pub/caps-softpaq/cmit/whitepapers/BIOS_Configuration_Utility_User_Guide.pdf
+$bcuArgs = @("/setconfig:$policyPath", "/log:$bcuLog")
+if (-not [string]::IsNullOrEmpty($env:HPBiosAdminPasswordFile) -and (Test-Path -Path $env:HPBiosAdminPasswordFile)) {
+    $bcuArgs += "/cspwdfile:$env:HPBiosAdminPasswordFile"
+}
+
+$proc = Start-Process -FilePath $bcu -ArgumentList $bcuArgs -Wait -PassThru -NoNewWindow
+$bcuExit = $proc.ExitCode
+Write-Host "BCU exit code: $bcuExit"
+
+Remove-Item -Path $policyPath -Force -ErrorAction SilentlyContinue
+
+if ($TranscriptStarted) { Stop-Transcript }
+exit $bcuExit

--- a/oem-hp/hp-debloat.ps1
+++ b/oem-hp/hp-debloat.ps1
@@ -1,0 +1,221 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:LibTag                    - jsDelivr tag for shared libs (default: "release")
+
+$ScriptLogName = "hp-debloat.log"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:LibTag)) { $env:LibTag = "release" }
+
+# === LIB BOOTSTRAP ===
+# TODO: Replace REPLACE_WITH_REAL_HASH once libs land on @release.
+
+$libs = @(
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-shared/lib/oem-manufacturer-detect.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" }
+)
+foreach ($lib in $libs) {
+    $libPath = Join-Path $env:TEMP ([System.IO.Path]::GetFileName($lib.Url))
+    Invoke-WebRequest -Uri $lib.Url -OutFile $libPath -UseBasicParsing -ErrorAction Stop
+    $actual = (Get-FileHash -Path $libPath -Algorithm SHA256).Hash
+    if ($actual -ne $lib.Sha256) {
+        throw "Lib SHA256 mismatch for $($lib.Url). Expected $($lib.Sha256), got $actual."
+    }
+    . $libPath
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "HP Debloat"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+$manufacturer = Get-OEMManufacturer
+if ($manufacturer -ne "HP") {
+    Write-Host "Not an HP endpoint. Exiting."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+# HP consumer software to remove. HP Image Assistant, HP CMSL, HP BIOS Configuration
+# Utility, and enterprise security agents are intentionally NOT in this list ... they
+# are the vendor lifecycle tools this baseline deploys or protects.
+$hpBloatPatterns = @(
+    "HP Support Assistant",
+    "HP JumpStart",
+    "HP Notifications",
+    "HP Wolf Security",
+    "HP Wolf Security Application Support for Sure Sense",
+    "HP Wolf Security Application Support for Windows",
+    "HP Documentation",
+    "HP Sure Click",
+    "HP Sure Sense",
+    "HP Sure Sense Installer",
+    "HP Connection Optimizer",
+    "HP Audio Control",
+    "HP Mac Address Manager",
+    "McAfee Personal Security",
+    "McAfee Security",
+    "McAfee LiveSafe",
+    "McAfee WebAdvisor",
+    "Norton 360",
+    "Norton Security"
+)
+
+# Patterns to exclude even if they match a bloat pattern (keep these installed).
+$keepPatterns = @(
+    "HP Image Assistant",
+    "hp-hpia",
+    "HP CMSL",
+    "HP Client Management Script Library",
+    "HP BIOS Configuration Utility",
+    "HP Client Security Manager",
+    "HP System Default Settings"
+)
+
+function Test-ShouldKeep {
+    param([string] $Name)
+    foreach ($keep in $keepPatterns) {
+        if ($Name -match [regex]::Escape($keep)) { return $true }
+    }
+    return $false
+}
+
+$uninstallPaths = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+
+$removedCount = 0
+$failedCount = 0
+
+foreach ($pattern in $hpBloatPatterns) {
+    $matched = foreach ($path in $uninstallPaths) {
+        Get-ItemProperty -Path $path -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -and ($_.DisplayName -match [regex]::Escape($pattern)) }
+    }
+    foreach ($app in $matched) {
+        if (Test-ShouldKeep -Name $app.DisplayName) {
+            Write-Host "Keeping: $($app.DisplayName)"
+            continue
+        }
+        Write-Host "Removing: $($app.DisplayName) [$($app.DisplayVersion)]"
+        $uninstallString = $app.UninstallString
+        if ([string]::IsNullOrEmpty($uninstallString)) {
+            Write-Host "  No uninstall string; skipping."
+            continue
+        }
+        try {
+            if ($uninstallString -match "msiexec") {
+                if ($app.PSChildName -match "^\{[0-9A-Fa-f-]+\}$") {
+                    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $($app.PSChildName) /qn /norestart" -Wait -PassThru -NoNewWindow
+                    if ($proc.ExitCode -eq 0) { $removedCount++ } else { $failedCount++; Write-Host "  msiexec exit: $($proc.ExitCode)" }
+                } else {
+                    Write-Host "  Unknown product code shape: $($app.PSChildName)"
+                    $failedCount++
+                }
+            } else {
+                $cmd = $uninstallString
+                if ($cmd -notmatch "/S" -and $cmd -notmatch "/silent" -and $cmd -notmatch "/quiet") {
+                    $cmd = "$cmd /S"
+                }
+                $proc = Start-Process -FilePath "cmd.exe" -ArgumentList "/c $cmd" -Wait -PassThru -NoNewWindow
+                if ($proc.ExitCode -eq 0) { $removedCount++ } else { $failedCount++; Write-Host "  uninstaller exit: $($proc.ExitCode)" }
+            }
+        } catch {
+            Write-Host "  Removal threw: $_"
+            $failedCount++
+        }
+    }
+}
+
+# Provisioned UWP / AppX consumer bundles ship preinstalled on HP consumer SKUs.
+# HP's consumer publisher ID is AD2F1837.
+$appxPatterns = @(
+    "*AD2F1837.HPJumpStart*",
+    "*AD2F1837.HPQuickDrop*",
+    "*AD2F1837.HPEasyClean*",
+    "*AD2F1837.HPPowerManager*",
+    "*AD2F1837.HPPrivacySettings*",
+    "*AD2F1837.HPProgrammableKey*",
+    "*AD2F1837.HPWorkWell*",
+    "*AD2F1837.myHP*",
+    "*AD2F1837.HPSystemInformation*",
+    "*AD2F1837.HPPCHardwareDiagnosticsWindows*"
+)
+
+foreach ($pattern in $appxPatterns) {
+    $pkgs = Get-AppxPackage -AllUsers -Name $pattern -ErrorAction SilentlyContinue
+    foreach ($pkg in $pkgs) {
+        Write-Host "Removing AppX: $($pkg.Name)"
+        try {
+            Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop
+            $removedCount++
+        } catch {
+            Write-Host "  Remove-AppxPackage failed: $_"
+            $failedCount++
+        }
+    }
+    $provisioned = Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like $pattern.Trim('*') -or $_.PackageName -like $pattern }
+    foreach ($prov in $provisioned) {
+        Write-Host "Removing provisioned AppX: $($prov.DisplayName)"
+        try {
+            Remove-AppxProvisionedPackage -Online -PackageName $prov.PackageName -ErrorAction Stop | Out-Null
+            $removedCount++
+        } catch {
+            Write-Host "  Remove-AppxProvisionedPackage failed: $_"
+            $failedCount++
+        }
+    }
+}
+
+Write-Host "`nSummary: removed=$removedCount failed=$failedCount"
+
+if ($TranscriptStarted) { Stop-Transcript }
+
+if ($failedCount -gt 0) { exit 1 } else { exit 0 }

--- a/oem-hp/hp-image-assistant-install.ps1
+++ b/oem-hp/hp-image-assistant-install.ps1
@@ -1,0 +1,133 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:HPIATargetVersion         - Minimum acceptable HPIA version (default: "5.3.4")
+## $env:HPIAInstallerURL          - Override HP-hosted installer URL (default: see below)
+## $env:HPIAInstallerSha256       - SHA256 of the installer EXE (TODO: capture and pin)
+## $env:LibTag                    - jsDelivr tag for shared libs (default: "release")
+
+$ScriptLogName = "hp-image-assistant-install.log"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:HPIATargetVersion)) { $env:HPIATargetVersion = "5.3.4" }
+# TODO: Confirm the canonical HP-hosted EXE URL for HPIA 5.3.4 from
+# https://ftp.ext.hp.com/pub/caps-softpaq/cmit/HPIA.html and pin it.
+if ([string]::IsNullOrEmpty($env:HPIAInstallerURL)) {
+    $env:HPIAInstallerURL = "https://hpia.hpcloud.hp.com/downloads/hpia/hp-hpia-5.3.4.exe"
+}
+# TODO: Capture SHA256 of the installer once the canonical URL is confirmed.
+if ([string]::IsNullOrEmpty($env:HPIAInstallerSha256)) {
+    $env:HPIAInstallerSha256 = "REPLACE_WITH_REAL_HASH"
+}
+if ([string]::IsNullOrEmpty($env:LibTag)) { $env:LibTag = "release" }
+
+# === LIB BOOTSTRAP ===
+# TODO: Replace REPLACE_WITH_REAL_HASH once libs land on @release.
+
+$libs = @(
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-shared/lib/oem-manufacturer-detect.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" },
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/lib/hp-detection.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" }
+)
+foreach ($lib in $libs) {
+    $libPath = Join-Path $env:TEMP ([System.IO.Path]::GetFileName($lib.Url))
+    Invoke-WebRequest -Uri $lib.Url -OutFile $libPath -UseBasicParsing -ErrorAction Stop
+    $actual = (Get-FileHash -Path $libPath -Algorithm SHA256).Hash
+    if ($actual -ne $lib.Sha256) {
+        throw "Lib SHA256 mismatch for $($lib.Url). Expected $($lib.Sha256), got $actual."
+    }
+    . $libPath
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "HP Image Assistant Install"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-HPHardware)) {
+    Write-Host "Not an HP endpoint. Exiting."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+$targetVersion = [version]$env:HPIATargetVersion
+$installedVersion = Get-HPIAVersion
+
+if ($null -ne $installedVersion -and $installedVersion -ge $targetVersion) {
+    Write-Host "HPIA $installedVersion already meets target $targetVersion. Skipping install."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+Write-Host "HPIA installed: $installedVersion. Target: $targetVersion. Installing."
+
+$installerPath = Join-Path $env:TEMP "hp-image-assistant-installer.exe"
+try {
+    Get-VerifiedDownload -Url $env:HPIAInstallerURL -OutFile $installerPath -Sha256 $env:HPIAInstallerSha256 | Out-Null
+} catch {
+    Write-Host "Failed to download HPIA installer: $_"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}
+
+Write-Host "Running silent install: $installerPath /s"
+$proc = Start-Process -FilePath $installerPath -ArgumentList "/s" -Wait -PassThru -NoNewWindow
+Write-Host "Installer exit code: $($proc.ExitCode)"
+
+Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
+
+$postVersion = Get-HPIAVersion
+if ($null -ne $postVersion -and $postVersion -ge $targetVersion) {
+    Write-Host "HPIA $postVersion installed successfully."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+} else {
+    Write-Host "HPIA install verification failed. Installed version: $postVersion"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}

--- a/oem-hp/hp-image-assistant-run.ps1
+++ b/oem-hp/hp-image-assistant-run.ps1
@@ -1,0 +1,160 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:HPIAScanOnly              - "1" to analyze without applying updates (default: "0")
+## $env:HPIACategory              - HPIA /Category value (default: "Drivers,Software,Firmware,BIOS")
+## $env:HPIAReportFolder          - HPIA /ReportFolder path (default: "C:\ProgramData\DTC\HPIA\Report")
+## $env:HPIASoftpaqFolder         - HPIA /SoftpaqDownloadFolder path (default: "C:\ProgramData\DTC\HPIA\Softpaqs")
+## $env:LibTag                    - jsDelivr tag for shared libs (default: "release")
+
+$ScriptLogName = "hp-image-assistant-run.log"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:HPIAScanOnly))      { $env:HPIAScanOnly      = "0" }
+if ([string]::IsNullOrEmpty($env:HPIACategory))      { $env:HPIACategory      = "Drivers,Software,Firmware,BIOS" }
+if ([string]::IsNullOrEmpty($env:HPIAReportFolder))  { $env:HPIAReportFolder  = "C:\ProgramData\DTC\HPIA\Report" }
+if ([string]::IsNullOrEmpty($env:HPIASoftpaqFolder)) { $env:HPIASoftpaqFolder = "C:\ProgramData\DTC\HPIA\Softpaqs" }
+if ([string]::IsNullOrEmpty($env:LibTag))            { $env:LibTag            = "release" }
+
+# === LIB BOOTSTRAP ===
+# TODO: Replace REPLACE_WITH_REAL_HASH once libs land on @release.
+
+$libs = @(
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-shared/lib/oem-manufacturer-detect.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" },
+    @{ Url = "https://cdn.jsdelivr.net/gh/dtc-inc/msp-script-library@$($env:LibTag)/oem-hp/lib/hp-detection.ps1"
+       Sha256 = "REPLACE_WITH_REAL_HASH" }
+)
+foreach ($lib in $libs) {
+    $libPath = Join-Path $env:TEMP ([System.IO.Path]::GetFileName($lib.Url))
+    Invoke-WebRequest -Uri $lib.Url -OutFile $libPath -UseBasicParsing -ErrorAction Stop
+    $actual = (Get-FileHash -Path $libPath -Algorithm SHA256).Hash
+    if ($actual -ne $lib.Sha256) {
+        throw "Lib SHA256 mismatch for $($lib.Url). Expected $($lib.Sha256), got $actual."
+    }
+    . $libPath
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "HP Image Assistant Run"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-HPHardware)) {
+    Write-Host "Not an HP endpoint. Exiting."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+if (-not (Test-HPIAInstalled)) {
+    Write-Host "HP Image Assistant is not installed. Run hp-image-assistant-install.ps1 first."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 2
+}
+
+$hpia = Get-HPIAPath
+Write-Host "HPIA: $hpia (version $(Get-HPIAVersion))"
+
+# Ensure report + softpaq folders exist so HPIA can write into them.
+foreach ($folder in @($env:HPIAReportFolder, $env:HPIASoftpaqFolder)) {
+    if (-not (Test-Path -Path $folder)) {
+        New-Item -Path $folder -ItemType Directory -Force | Out-Null
+    }
+}
+
+# Reference: https://ftp.hp.com/pub/caps-softpaq/cmit/whitepapers/HPIAUserGuide.pdf
+# Exit codes for /Operation:Analyze /Action:Install (16-bit packed):
+#   0    = success, completed (or nothing to do)
+#   256  = analyze returned no recommendations; treat as success
+#   257  = success, reboot required
+#   3010 = SoftPaqs installed, one or more require reboot
+#   4096 / 4097 / 8194 / 8199 = failure paths (log + non-zero exit)
+
+if ($env:HPIAScanOnly -eq "1") {
+    Write-Host "`n--- HPIA /Operation:Analyze /Action:List (scan only) ---"
+    $hpiaArgs = @(
+        "/Operation:Analyze",
+        "/Action:List",
+        "/Category:$env:HPIACategory",
+        "/Silent",
+        "/ReportFolder:$env:HPIAReportFolder"
+    )
+    $scan = Start-Process -FilePath $hpia -ArgumentList $hpiaArgs -Wait -PassThru -NoNewWindow
+    Write-Host "Scan exit code: $($scan.ExitCode)"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit $scan.ExitCode
+}
+
+Write-Host "`n--- HPIA /Operation:Analyze /Action:Install ---"
+$hpiaArgs = @(
+    "/Operation:Analyze",
+    "/Action:Install",
+    "/Category:$env:HPIACategory",
+    "/Selection:All",
+    "/Silent",
+    "/ReportFolder:$env:HPIAReportFolder",
+    "/SoftpaqDownloadFolder:$env:HPIASoftpaqFolder",
+    "/AutoCleanup:Enable"
+)
+$apply = Start-Process -FilePath $hpia -ArgumentList $hpiaArgs -Wait -PassThru -NoNewWindow
+$applyExit = $apply.ExitCode
+Write-Host "Apply exit code: $applyExit"
+
+switch ($applyExit) {
+    0    { Write-Host "HPIA completed successfully." }
+    256  { Write-Host "HPIA analyzed and returned no recommendations." }
+    257  { Write-Host "Updates applied; reboot required to complete." }
+    3010 { Write-Host "SoftPaqs installed; one or more require reboot." }
+    4096 { Write-Host "HPIA failure: general error." }
+    4097 { Write-Host "HPIA failure: invalid parameters." }
+    8194 { Write-Host "HPIA failure: download error." }
+    8199 { Write-Host "HPIA failure: install error." }
+    default { Write-Host "Unrecognized HPIA exit code: $applyExit" }
+}
+
+if ($TranscriptStarted) { Stop-Transcript }
+exit $applyExit

--- a/oem-hp/lib/hp-detection.ps1
+++ b/oem-hp/lib/hp-detection.ps1
@@ -1,0 +1,65 @@
+# oem-hp/lib/hp-detection.ps1
+#
+# HP-specific detection helpers. Fetched at runtime alongside the shared
+# OEM lib by the lib bootstrap block in each HP leaf script.
+#
+# Provides:
+#   Test-HPHardware         True if this machine is HP.
+#   Get-HPInstalledModel    Returns Win32_ComputerSystem.Model or $null.
+#   Test-HPIAInstalled      True if HPImageAssistant.exe is present at a known path.
+#   Get-HPIAVersion         Returns [version] of the installed HPIA, or $null.
+#   Get-HPIAPath            Returns the resolved HPIA path, or $null.
+#   Get-HPBCUPath           Returns the resolved BCU path, or $null.
+
+$script:hpiaCandidates = @(
+    "$env:ProgramFiles\HP\HPIA\HPImageAssistant.exe",
+    "${env:ProgramFiles(x86)}\HP\HPIA\HPImageAssistant.exe"
+)
+
+$script:bcuCandidates = @(
+    "${env:ProgramFiles(x86)}\Hewlett-Packard\BIOS Configuration Utility\BiosConfigUtility64.exe",
+    "$env:ProgramFiles\Hewlett-Packard\BIOS Configuration Utility\BiosConfigUtility64.exe",
+    "${env:ProgramFiles(x86)}\HP\BIOS Configuration Utility\BiosConfigUtility64.exe",
+    "$env:ProgramFiles\HP\BIOS Configuration Utility\BiosConfigUtility64.exe"
+)
+
+function Test-HPHardware {
+    $manufacturer = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Manufacturer
+    return ($manufacturer -like "HP*" -or $manufacturer -like "Hewlett*")
+}
+
+function Get-HPInstalledModel {
+    return (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Model
+}
+
+function Get-HPIAPath {
+    foreach ($candidate in $script:hpiaCandidates) {
+        if (Test-Path -Path $candidate) { return $candidate }
+    }
+    return $null
+}
+
+function Test-HPIAInstalled {
+    return ($null -ne (Get-HPIAPath))
+}
+
+function Get-HPIAVersion {
+    $path = Get-HPIAPath
+    if (-not $path) { return $null }
+    try {
+        $info = (Get-Item -Path $path -ErrorAction Stop).VersionInfo
+        if ($info.ProductVersion) {
+            return [version]$info.ProductVersion
+        }
+        return $null
+    } catch {
+        return $null
+    }
+}
+
+function Get-HPBCUPath {
+    foreach ($candidate in $script:bcuCandidates) {
+        if (Test-Path -Path $candidate) { return $candidate }
+    }
+    return $null
+}


### PR DESCRIPTION
## Summary

Replicates the OEM hybrid pattern (orchestrator + vendor-tool leaves + inline-config leaves with jsDelivr lib bootstrap and SHA256 verification) for HP, following the Dell prototype landed in #69.

Closes #70.

## Components

- `oem-hp/hp-baseline.ps1` ... orchestrator. Detects manufacturer, fetches and invokes each enabled leaf from jsDelivr, reports status to a Ninja custom field.
- `oem-hp/hp-image-assistant-install.ps1` ... idempotent HPIA install. Downloads `hp-hpia-<version>.exe`, verifies SHA256, runs `/s`, verifies version post-install.
- `oem-hp/hp-image-assistant-run.ps1` ... `/Operation:Analyze /Action:Install /Category:Drivers,Software,Firmware,BIOS /Selection:All /Silent` with `/ReportFolder` and `/SoftpaqDownloadFolder` set to `C:\ProgramData\DTC\HPIA\`. Parses HPIA exit codes (0/256/257/3010 = success, 4096/4097/8194/8199 = failure).
- `oem-hp/hp-bios-config.ps1` ... fetches `dtc-baseline.repset` from jsDelivr, applies via `BiosConfigUtility64.exe /setconfig:... /log:...`, supports optional password file via `/cspwdfile`.
- `oem-hp/hp-debloat.ps1` ... removes HP consumer software (Support Assistant, JumpStart, Wolf Security, Connection Optimizer, etc.) and the `AD2F1837.*` provisioned AppX bundles. Keep-list protects HPIA, HP CMSL, BCU, Client Security Manager, and System Default Settings.
- `oem-hp/lib/hp-detection.ps1` ... `Test-HPHardware` (covers `HP*` and `Hewlett*` manufacturer strings), `Get-HPInstalledModel`, `Test-HPIAInstalled`, `Get-HPIAVersion`, `Get-HPIAPath`, `Get-HPBCUPath`.

Reuses the shared helpers from #69 (`Get-OEMManufacturer`, `Get-VerifiedDownload`) at `oem-shared/lib/oem-manufacturer-detect.ps1`. No new shared helpers added.

## Conventions held

- `$env:VAR` contract everywhere; `$env:RMM` compared against `"1"`.
- Three-section structure (RMM vars / input handling / script logic).
- `Start-Transcript` / `Stop-Transcript` with the `$TranscriptStarted` guard pattern (#34).
- camelCase variables, kebab-case filenames.
- No em dashes in script comments, no AI tells.

## TODOs captured in code

Each is marked with an explicit `# TODO:` comment in the file that needs it.

- `hp-image-assistant-install.ps1` ... confirm canonical HPIA EXE URL on the HPIA index page; capture SHA256 of `hp-hpia-5.3.4.exe` into `$env:HPIAInstallerSha256`.
- `hp-bios-config.ps1` ... author `oem-hp/policy/dtc-baseline.repset` by exporting from a known-good HP with `BiosConfigUtility64.exe /getconfig:current.repset`, editing the active-value markers (`*`) to the DTC baseline, and committing at that path. Capture its SHA256 into `$env:HPBiosPolicySha256`.
- All lib-bootstrap blocks and leaf-invoke calls in `hp-baseline.ps1` ... replace `REPLACE_WITH_REAL_HASH` placeholders once the libs and leaves land on the `@release` tag (same pattern as the Dell PR).

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` passes clean on all six scripts (no syntax errors, no parse warnings).
- Grep for `[—–]` (em / en dash) across `oem-hp/` returns no matches.
- File shape and conventions visually diffed against the Dell prototype at `origin/feature/oem-hybrid-pattern-dell`.

## Notes for follow-up testing on a live HP endpoint

- Validate HPIA install path resolves to `C:\Program Files\HP\HPIA\` (some installer versions have landed at `C:\Program Files (x86)\HP\HPIA\`; the detection lib checks both).
- Validate BCU install path resolves correctly (lib checks both `Hewlett-Packard` and `HP` subfolders under Program Files and Program Files (x86)).
- Confirm exit codes 257 vs 3010 behave as expected on a machine with pending updates.
- Capture all SHA256 TODOs into the lib-bootstrap pinning before tagging `@release`.
