### PR TITLE
feature(oem): Dell OEM hybrid pattern (self-contained scripts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,88 @@ if ($veeamVersion -ge $requiredVersion) {
 }
 ```
 
+### OEM Vendor Scripts
+
+OEM scripts (`oem-dell/`, `oem-hp/`, `oem-lenovo/`) deploy and operate the vendor lifecycle tools for endpoint hardware ... BIOS configuration, driver/firmware updates, and consumer-software debloat. Each OEM follows the same four-leaf shape and the same patterns.
+
+#### The four-leaf shape
+
+Every OEM lives at the repo root under `oem-<vendor>/` and ships exactly four scripts, each independently runnable from RMM. RMM presets compose them per device-class:
+
+| Leaf | Purpose | Internet check? |
+|---|---|---|
+| `<oem>-configure.ps1` | Apply BIOS settings from `$env:BIOS_*` env vars. Operates on already-installed Command Configure / equivalent tooling. | No |
+| `<oem>-command-update-install.ps1` | Install or upgrade the vendor update tool (Dell Command Update, HP Image Assistant, Lenovo System Update). | Yes |
+| `<oem>-command-update-run.ps1` | Scan + apply driver/firmware updates via the vendor CLI. Operates on already-installed tooling. | No |
+| `<oem>-debloat.ps1` | Uninstall the vendor's consumer software (e.g. SupportAssist, MyDell). Keeps the lifecycle tools. | No |
+
+Each leaf is self-contained: its OEM detection, vendor-tool detection, and translation tables are inlined directly in the file. No `lib/` subfolder, no `src/`, no build system. Helpers that multiple leaves need get duplicated across those leaves.
+
+#### `configure` not `baseline`
+
+The leaf is named `<oem>-configure.ps1`, not `<oem>-baseline.ps1`. The RMM operator's env-var set is the desired state. There is no static policy file in the repo. The naming is explicit so contributors don't go looking for a `.cctk` / `.repset` / WMI policy that doesn't exist.
+
+#### `$env:BIOS_*` canonical settings table
+
+Settings are operator-set via canonical environment variables. Each `<oem>-configure.ps1` carries its own per-OEM translation map inline that maps canonical names to vendor-native syntax. Unknown canonical names or unsupported values are logged and skipped so forward-looking presets don't break the run.
+
+| Canonical variable | Type / allowed values | Dell | HP | Lenovo |
+|---|---|---|---|---|
+| `$env:BIOS_AdminPassword` | string (current admin pw, required to apply settings) | yes | yes | yes |
+| `$env:BIOS_AdminPasswordNew` | string (new admin pw to set; empty = no change) | yes | yes | yes |
+| `$env:BIOS_TPMEnabled` | `Enabled` / `Disabled` | yes | yes | yes |
+| `$env:BIOS_TPMActivation` | `Activated` / `Deactivated` | yes | n/a (HP couples activation with enable) | yes |
+| `$env:BIOS_SecureBoot` | `Enabled` / `Disabled` | yes | yes | yes |
+| `$env:BIOS_VirtualizationCPU` | `Enabled` / `Disabled` | yes | yes | yes |
+| `$env:BIOS_VirtualizationIOMMU` | `Enabled` / `Disabled` | yes | yes | yes |
+| `$env:BIOS_WakeOnLAN` | `Enabled` / `Disabled` / `LANOnly` / `LANWLAN` | yes (Dell maps `Enabled` -> `lan`) | yes | yes |
+| `$env:BIOS_BootMode` | `UEFI` / `Legacy` | yes | yes | yes |
+
+Operators set the vars they want to apply; leave the rest blank. Each `<oem>-configure.ps1` iterates the canonical names, looks each up in its inline translation table, and emits the vendor-native call.
+
+#### Internet check pattern (install leaves only)
+
+`*-command-update-install.ps1` is the only leaf that needs vendor download connectivity. It checks before pulling the installer and skips cleanly when offline:
+
+```powershell
+function Test-InternetAvailable {
+    try {
+        $resp = Invoke-WebRequest -Uri 'https://www.msftconnecttest.com/connecttest.txt' `
+            -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        return ($resp.StatusCode -eq 200)
+    } catch {
+        return $false
+    }
+}
+
+if (-not (Test-InternetAvailable)) {
+    Write-Host "No internet connectivity detected ... skipping vendor install. Exit 0."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+```
+
+The other three leaves (`*-configure`, `*-command-update-run`, `*-debloat`) operate on already-installed tooling and intentionally do **not** include the internet check. They should still run on an endpoint that's momentarily offline.
+
+#### Self-contained guidance
+
+Each OEM leaf is independently runnable from RMM and inlines its own helpers (manufacturer check, vendor-tool detection, BIOS translation table, internet check where needed). The trade-off versus a shared `lib/` is intentional:
+
+- Duplicated helpers across Dell + HP + Lenovo land in the 30-50 line range.
+- Reading any one script tells you exactly what it does without grepping for includes or fat-script build output.
+- No build system to operate, no `published/` branch, no marker syntax to learn.
+
+If you find yourself wanting to share a helper across many scripts, copy it. Sweep drift via a Pester test or a periodic refactor PR ... not a build pipeline.
+
+The standard gate sequence after the RMM-vs-interactive section:
+
+1. Manufacturer check ... `if (-not (Test-DellHardware)) { Write-Host "Not a Dell endpoint. Skipping."; exit 0 }`
+2. (Install leaves only) `if (-not (Test-InternetAvailable)) { Write-Host "Offline. Skipping vendor install."; exit 0 }`
+3. Vendor-tool presence check where required (e.g. `Test-DCUInstalled` for `dell-command-update-run`).
+4. Do the actual work.
+
+Canonical example: `oem-dell/dell-configure.ps1`, `oem-dell/dell-command-update-install.ps1`, `oem-dell/dell-command-update-run.ps1`, `oem-dell/dell-debloat.ps1`.
+
 ## Testing Scripts
 
 - **Interactive Testing**: Run script directly in PowerShell without setting `$env:RMM`. The script will prompt for `$env:Description` via `Read-Host`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ All scripts follow a consistent three-part structure defined in `script-template
 Scripts are organized by category prefixes:
 - `app-*`: Application-specific scripts (Duo, Adobe, Teramind, etc.)
 - `bdr-*`: Backup and Disaster Recovery (Veeam, MSP360)
+- `db-*`: Database engines (MySQL, etc.)
 - `iaas-*`: Infrastructure as a Service (Azure, Backblaze, Dynu)
 - `mw-*`: Middleware/Microsoft 365 scripts
 - `msft-*`: Microsoft Windows system scripts
@@ -533,13 +534,100 @@ if ($veeamVersion -ge $requiredVersion) {
 
 ## Git Workflow
 
-**Branching Model:**
-* `development` — default branch (HEAD), active work lands here
-* `release` — stable/production branch, merged from development when ready
-* `enhancement/{name}` — branched from development for new functionality
-* `problem/{name}` — branched from development for bug fixes and issue resolution
-* No `main` or `master` branches
+See [DTC KB ... Change Taxonomy](https://kb.dtctoday.com/books/developer-operations-devops/page/change-taxonomy) for the canonical reference. This file mirrors the rules; the KB is authoritative.
 
-**GitHub Issues & Labels:**
-* New functionality uses the **enhancement** label, not "feature"
-* Configure repository labels accordingly
+**Branching Model:**
+* `main` ... default branch and release branch. Production code deployed to customer environments lives here.
+* This repo has no `development` branch. Feature/fix PRs target `main` directly.
+* All changes go through a typed branch and a pull request ... no direct commits to `main` (exception: minor `CLAUDE.md` / `README.md` doc updates that do not affect script functionality).
+
+**CRITICAL: All changes must be made in a typed branch, never directly to `main`.**
+
+### Change Taxonomy (two-tier ... Halo / GitHub / branch)
+
+Every change to this repo maps to one of four categories under two parent types. The category drives the branch prefix, the GitHub labels, and the default semver bump (future-state: this repo has no semver versioning today, but the bump column is recorded for when it does). `Refactor` spans both parent types ... see the table.
+
+| Halo Type | Halo Category | GitHub labels | Branch prefix | Default semver |
+|---|---|---|---|---|
+| `Problem` | `Bug` | `type:problem` + `category:bug` | `bug/{name}` | Patch |
+| `Problem` | `Refactor` | `type:problem` + `category:refactor` | `refactor/{name}` | Patch |
+| `Enhancement` | `Feature` | `type:enhancement` + `category:feature` | `feature/{name}` | Minor |
+| `Enhancement` | `Improvement` | `type:enhancement` + `category:improvement` | `improvement/{name}` | Minor |
+| `Enhancement` | `Refactor` | `type:enhancement` + `category:refactor` | `refactor/{name}` | Minor |
+
+How to pick:
+- **Bug** ... the script doesn't do what it was designed to do. Null check missing, wrong path, broken regex, off-by-one.
+- **Refactor** ... a redesign of how something is shaped. Spans both parent types ... `Problem/Refactor` when the original design was wrong (broken-shape redo, patch bump); `Enhancement/Refactor` when the original design works but is clunky (working-but-clunky redo, minor bump). Same branch prefix and same `category:refactor` label either way; the parent type column disambiguates motivation and semver.
+- **Improvement** ... an existing capability done better. Hardening, polish, clearer error output, integrity checks added to existing downloads.
+- **Feature** ... net-new capability. A new script, new delivery mechanism, new integration target.
+
+**`BREAKING:` PR title prefix** forces a major version bump regardless of category. (Future-state: applies once this repo carries a semver version.)
+
+**Name branches after the change, not the fix.** Good: `bug/iso-dismount-fails-on-server-2022`, `feature/jsdelivr-script-delivery`. Bad: `bug/my-fix`, `feature/wip`.
+
+**`dependabot/*` branches** ... categorize by the upstream change. CVE or upstream defect → `bug`. Major-version bump that takes new capability → `improvement` or `feature`.
+
+**Legacy prefixes:** `enhancement/` and `problem/` are deprecated by this taxonomy. Existing branches with these prefixes are accepted as-is and can merge under their original names; new work uses the four-prefix model above (`bug/`, `refactor/`, `improvement/`, `feature/`).
+
+### GitHub Labels
+
+Two-tier label set, one of each per PR:
+
+**Type labels:** `type:problem`, `type:enhancement`
+
+**Category labels:** `category:bug`, `category:refactor`, `category:improvement`, `category:feature`
+
+The legacy single-tier labels (`bug`, `enhancement`, `feature`) remain on the repo for issues opened under the old convention. New issues and PRs use the two-tier labels.
+
+### Workflow for All Changes
+
+1. **Create a typed branch off `main`**
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b feature/descriptive-name
+   # or bug/, refactor/, improvement/ per the taxonomy above
+   ```
+
+   Examples:
+   - `feature/jsdelivr-script-delivery`
+   - `improvement/vendor-download-integrity`
+   - `bug/iso-dismount-error`
+   - `refactor/rmm-input-handler-shared-helper`
+
+2. **Make changes on the branch**
+   - Make all code modifications on the typed branch
+   - Commit changes with descriptive messages
+   - Test thoroughly in both interactive and RMM modes
+
+3. **Push branch**
+   ```bash
+   git push -u origin feature/descriptive-name
+   ```
+
+4. **Create pull request**
+   - Open PR from your branch to `main`
+   - Apply the two labels from the taxonomy table (one `type:*` + one `category:*`)
+   - Include description of changes, testing performed, and RMM compatibility
+   - Wait for review and approval before merging
+
+5. **Merge to `main`**
+   - Only merge after testing and approval
+   - Delete the branch after successful merge
+
+### If Changes Are Accidentally Committed to Main
+
+```bash
+# Revert the commit from main
+git revert <commit-hash> --no-edit
+git push
+
+# Create the typed branch and restore the changes
+git checkout -b feature/descriptive-name
+git cherry-pick <commit-hash>
+git push -u origin feature/descriptive-name
+```
+
+### Exception: Documentation Updates
+
+Minor documentation updates to `CLAUDE.md` or `README.md` may be committed directly to `main` if they do not affect script functionality.

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,0 +1,177 @@
+<#
+.SYNOPSIS
+    Syncs DTC Org GUID from NinjaRMM organizations to Halo PSA client custom field.
+
+.DESCRIPTION
+    Reads the dtcOrgGuid custom field from each NinjaRMM organization and writes
+    it to the CFDtcClientGuid field in Halo PSA for all exactly-matched clients.
+
+    Runs unattended via NinjaOne Scheduled Task (Sundays 2:00 AM EDT).
+    Matching is exact by client name. Name mismatches are logged and skipped.
+
+.PARAMETER haloclientsecret
+    Halo PSA API client secret. Injected by NinjaOne Script Variable: haloclientsecret.
+
+.PARAMETER ninjaclientsecret
+    NinjaRMM API client secret. Injected by NinjaOne Script Variable: ninjaclientsecret.
+
+.NOTES
+    Author:      Tyler Dantzler
+    Repo:        DTC-Inc/msp-script-library/integrations/ninja-halo-guid-sync.ps1
+    BookStack:   Page 1908
+    Schedule:    Weekly, Sundays 2:00 AM EDT (NinjaOne Scheduled Task)
+
+    ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU ARE RUNNING FROM A RMM
+    # $env:RMM             -- set to "1" by NinjaOne at runtime; controls RMM vs interactive mode
+    # $env:Description     -- human-readable audit trail label for this run
+    # $env:haloclientsecret  -- Halo PSA API client secret (NinjaOne Script Variable)
+    # $env:ninjaclientsecret -- NinjaRMM API client secret (NinjaOne Script Variable)
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+# --- AUDIT TRAIL & LOGGING ---
+$ScriptLogName = 'ninja-halo-guid-sync'
+$Description   = if ($env:Description) { $env:Description } else { 'NinjaRMM to Halo PSA GUID sync (manual run)' }
+$logPath       = "C:\ProgramData\DTC\Logs\$ScriptLogName-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+New-Item -ItemType Directory -Path (Split-Path $logPath) -Force | Out-Null
+Start-Transcript -Path $logPath -Append
+
+Write-Information "[$ScriptLogName] Starting — $Description" -InformationAction Continue
+
+try {
+
+    # --- CONFIGURATION ---
+    # Client IDs are not secrets — hardcoded here.
+    # Client secrets are injected via NinjaOne Script Variables (env vars at runtime).
+    $HaloClientId      = '25542a6d-2d0e-4093-bf82-e11edc64faf6'
+    $HaloClientSecret  = $env:haloclientsecret
+    $HaloBaseUrl       = 'https://psa.dtctoday.com'
+    $HaloScope         = 'read:customers edit:customers'
+
+    $NinjaClientId     = '0S1xEjce1FQp7Rbn_GJTrSWTp64'
+    $NinjaClientSecret = $env:ninjaclientsecret
+    $NinjaBaseUrl      = 'https://app.ninjarmm.com'
+
+    # --- VALIDATE SECRETS ---
+    $missing = @()
+    if ([string]::IsNullOrWhiteSpace($HaloClientSecret))  { $missing += 'haloclientsecret' }
+    if ([string]::IsNullOrWhiteSpace($NinjaClientSecret)) { $missing += 'ninjaclientsecret' }
+
+    if ($missing.Count -gt 0) {
+        throw "Missing NinjaOne Script Variables: $($missing -join ', '). Set default values in Library > Automation > Halo GUID Sync > Script Variables."
+    }
+
+    # --- AUTHENTICATE: HALO ---
+    Write-Information '  Authenticating with Halo PSA...' -InformationAction Continue
+    $haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token" `
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
+            client_id     = $HaloClientId
+            client_secret = $HaloClientSecret
+            scope         = $HaloScope
+        }
+    $haloToken   = $haloTokenResp.access_token
+    $haloHeaders = @{ Authorization = "Bearer $haloToken" }
+    Write-Information '  Halo auth OK' -InformationAction Continue
+
+    # --- AUTHENTICATE: NINJA ---
+    Write-Information '  Authenticating with NinjaRMM...' -InformationAction Continue
+    $ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" `
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
+            client_id     = $NinjaClientId
+            client_secret = $NinjaClientSecret
+            scope         = 'monitoring management'
+        }
+    $ninjaToken   = $ninjaTokenResp.access_token
+    $ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+    Write-Information '  Ninja auth OK' -InformationAction Continue
+
+    # --- PULL NINJA ORGS ---
+    $orgs    = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
+    $results = @()
+
+    foreach ($org in $orgs) {
+        $orgName = $org.name
+        $orgId   = $org.id
+
+        # Read DTC Org GUID custom field
+        try {
+            $cf   = Invoke-RestMethod -Method Get `
+                -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+            $guid = $cf.dtcOrgGuid
+        } catch {
+            Write-Warning "Could not read custom fields for '$orgName' — skipping"
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($guid)) {
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No GUID'; GUID = '' }
+            continue
+        }
+
+        # Search Halo for matching client by exact name
+        try {
+            $haloSearch = Invoke-RestMethod -Method Get `
+                -Uri "$HaloBaseUrl/api/client?search=$([uri]::EscapeDataString($orgName))" `
+                -Headers $haloHeaders
+        } catch {
+            Write-Warning "Halo search failed for '$orgName' — skipping"
+            continue
+        }
+
+        $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
+
+        if (-not $haloClient) {
+            Write-Warning "No exact Halo match for '$orgName' — skipping"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No Halo match'; GUID = $guid }
+            continue
+        }
+
+        # Build body — PowerShell 5 unwraps single-item @() on ConvertTo-Json so manually wrap in []
+        $clientUpdate = @{
+            id           = $haloClient.id
+            customfields = @(
+                @{ name = 'CFDtcClientGuid'; value = $guid }
+            )
+        }
+        $body = '[' + ($clientUpdate | ConvertTo-Json -Depth 5) + ']'
+
+        try {
+            Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" `
+                -Headers $haloHeaders -ContentType 'application/json' -Body $body | Out-Null
+            Write-Information "  [OK] $orgName" -InformationAction Continue
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Updated'; GUID = $guid }
+        } catch {
+            $errorDetail = $_.ErrorDetails.Message
+            Write-Warning "Failed to update '$orgName' — $($_.Exception.Message) | $errorDetail"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Failed'; GUID = $guid }
+        }
+    }
+
+    # --- SUMMARY ---
+    Write-Information '' -InformationAction Continue
+    Write-Information '===== SYNC SUMMARY =====' -InformationAction Continue
+    $results | Format-Table -AutoSize
+
+    $failed = $results | Where-Object { $_.Status -eq 'Failed' }
+    if ($failed) {
+        Write-Warning "$($failed.Count) client(s) failed to update — see above"
+        exit 2
+    }
+
+    Write-Information "[$ScriptLogName] Completed successfully." -InformationAction Continue
+    exit 0
+
+} catch {
+    Write-Error "FAILED: $_"
+    Write-Error $_.ScriptStackTrace
+    exit 1
+} finally {
+    Stop-Transcript
+}

--- a/oem-dell/dell-command-update-install.ps1
+++ b/oem-dell/dell-command-update-install.ps1
@@ -1,0 +1,161 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:DCUTargetVersion          - Minimum acceptable DCU version (default: "5.7.0")
+## $env:DCUInstallerURL           - Override the Dell-hosted installer URL (see TODO below)
+
+$ScriptLogName = "dell-command-update-install.log"
+
+# --- Inlined helpers -----------------------------------------------------
+# This script is self-contained. The helpers below are duplicated across
+# Dell leaf scripts intentionally. See CLAUDE.md "OEM Vendor Scripts" for
+# the trade-off rationale.
+
+$script:dcuCliPath = "$env:ProgramFiles\Dell\CommandUpdate\dcu-cli.exe"
+
+function Test-DellHardware {
+    $manufacturer = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Manufacturer
+    return ($manufacturer -like "Dell*")
+}
+
+function Test-DCUInstalled {
+    return (Test-Path -Path $script:dcuCliPath)
+}
+
+function Get-DCUVersion {
+    if (-not (Test-DCUInstalled)) { return $null }
+    try {
+        $info = (Get-Item -Path $script:dcuCliPath -ErrorAction Stop).VersionInfo
+        if ($info.ProductVersion) {
+            return [version]$info.ProductVersion
+        }
+        return $null
+    } catch {
+        return $null
+    }
+}
+
+# Internet check ... only the install step needs vendor download connectivity.
+# dell-command-update-run / dell-configure / dell-debloat do NOT include this
+# because they operate on already-installed tooling and should still work on
+# an endpoint that's offline at the moment.
+function Test-InternetAvailable {
+    try {
+        $resp = Invoke-WebRequest -Uri 'https://www.msftconnecttest.com/connecttest.txt' `
+            -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        return ($resp.StatusCode -eq 200)
+    } catch {
+        return $false
+    }
+}
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:DCUTargetVersion)) { $env:DCUTargetVersion = "5.7.0" }
+
+# TODO: Confirm the canonical Dell-hosted EXE URL for DCU 5.7 Classic from
+# https://www.dell.com/support/kbdoc/en-us/000177325/dell-command-update and
+# pin it here. The placeholder below points at Dell's published download path
+# pattern but the specific folder ID needs to be captured from a fresh
+# manual download against the published KB so we know we're tracking the
+# Dell-supported build.
+if ([string]::IsNullOrEmpty($env:DCUInstallerURL)) {
+    $env:DCUInstallerURL = "https://dl.dell.com/FOLDER/Dell-Command-Update-Application_WIN_5.7.0_A00.EXE"
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "Dell Command Update Install"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-DellHardware)) {
+    Write-Host "Not a Dell endpoint. Skipping."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+if (-not (Test-InternetAvailable)) {
+    Write-Host "No internet connectivity detected ... skipping DCU install. If DCU is already installed, dell-command-update-run will still work. Exit 0."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+$targetVersion = [version]$env:DCUTargetVersion
+$installedVersion = Get-DCUVersion
+
+if ($null -ne $installedVersion -and $installedVersion -ge $targetVersion) {
+    Write-Host "DCU $installedVersion already meets target $targetVersion. Skipping install."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+Write-Host "DCU installed: $installedVersion. Target: $targetVersion. Installing."
+
+$installerPath = Join-Path $env:TEMP "dell-command-update-installer.exe"
+try {
+    Invoke-WebRequest -Uri $env:DCUInstallerURL -OutFile $installerPath -UseBasicParsing -ErrorAction Stop
+} catch {
+    Write-Host "Failed to download DCU installer from $env:DCUInstallerURL : $_"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}
+
+Write-Host "Running silent install: $installerPath /s"
+$proc = Start-Process -FilePath $installerPath -ArgumentList "/s" -Wait -PassThru -NoNewWindow
+Write-Host "Installer exit code: $($proc.ExitCode)"
+
+Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
+
+$postVersion = Get-DCUVersion
+if ($null -ne $postVersion -and $postVersion -ge $targetVersion) {
+    Write-Host "DCU $postVersion installed successfully."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+} else {
+    Write-Host "DCU install verification failed. Installed version: $postVersion"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 1
+}

--- a/oem-dell/dell-command-update-run.ps1
+++ b/oem-dell/dell-command-update-run.ps1
@@ -1,0 +1,146 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## Per-script variables:
+## $env:DCUScanOnly               - "1" to scan but not apply updates (default: "0")
+
+$ScriptLogName = "dell-command-update-run.log"
+
+# --- Inlined helpers -----------------------------------------------------
+# This script is self-contained. The helpers below are duplicated across
+# Dell leaf scripts intentionally. See CLAUDE.md "OEM Vendor Scripts" for
+# the trade-off rationale.
+
+$script:dcuCliPath = "$env:ProgramFiles\Dell\CommandUpdate\dcu-cli.exe"
+
+function Test-DellHardware {
+    $manufacturer = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Manufacturer
+    return ($manufacturer -like "Dell*")
+}
+
+function Test-DCUInstalled {
+    return (Test-Path -Path $script:dcuCliPath)
+}
+
+function Get-DCUVersion {
+    if (-not (Test-DCUInstalled)) { return $null }
+    try {
+        $info = (Get-Item -Path $script:dcuCliPath -ErrorAction Stop).VersionInfo
+        if ($info.ProductVersion) {
+            return [version]$info.ProductVersion
+        }
+        return $null
+    } catch {
+        return $null
+    }
+}
+
+function Get-DCUCliPath {
+    return $script:dcuCliPath
+}
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:DCUScanOnly)) { $env:DCUScanOnly = "0" }
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "Dell Command Update Run"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-DellHardware)) {
+    Write-Host "Not a Dell endpoint. Skipping."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+if (-not (Test-DCUInstalled)) {
+    Write-Host "Dell Command Update is not installed. Run dell-command-update-install.ps1 first."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 2
+}
+
+$dcu = Get-DCUCliPath
+Write-Host "DCU CLI: $dcu (version $(Get-DCUVersion))"
+
+# Reference: https://www.dell.com/support/manuals/en-us/command-update/dcu_rg/dell-command-update-cli-commands
+# Exit codes for /applyUpdates:
+#   0 = success, 1 = reboot required, 2 = unknown error, 3 = not a Dell system,
+#   4 = not admin, 5 = reboot pending, 6 = another instance running,
+#   7 = unsupported model, 8 = no update filters configured.
+
+Write-Host "`n--- dcu-cli /scan ---"
+$scan = Start-Process -FilePath $dcu -ArgumentList "/scan" -Wait -PassThru -NoNewWindow
+$scanExit = $scan.ExitCode
+Write-Host "Scan exit code: $scanExit"
+
+if ($env:DCUScanOnly -eq "1") {
+    Write-Host "DCUScanOnly is set. Skipping applyUpdates."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit $scanExit
+}
+
+Write-Host "`n--- dcu-cli /applyUpdates ---"
+$apply = Start-Process -FilePath $dcu -ArgumentList "/applyUpdates -autoSuspendBitLocker=enable -reboot=disable" -Wait -PassThru -NoNewWindow
+$applyExit = $apply.ExitCode
+Write-Host "Apply exit code: $applyExit"
+
+# TODO: Capture any additional exit codes observed during real-endpoint testing
+# (DCU has occasionally emitted undocumented codes on edge-case hardware).
+switch ($applyExit) {
+    0 { Write-Host "Updates applied successfully." }
+    1 { Write-Host "Updates applied; reboot required to complete." }
+    2 { Write-Host "Unknown application error." }
+    3 { Write-Host "Not a Dell system. (Should not reach here ... Test-DellHardware passed.)" }
+    4 { Write-Host "DCU CLI was not launched with administrative privilege." }
+    5 { Write-Host "A reboot was pending from a previous operation." }
+    6 { Write-Host "Another instance of DCU is already running." }
+    7 { Write-Host "DCU does not support the current system model." }
+    8 { Write-Host "No update filters have been applied or configured." }
+    default { Write-Host "Unrecognized exit code: $applyExit" }
+}
+
+if ($TranscriptStarted) { Stop-Transcript }
+exit $applyExit

--- a/oem-dell/dell-configure.ps1
+++ b/oem-dell/dell-configure.ps1
@@ -1,0 +1,263 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+##
+## BIOS settings (operator sets the ones they want to apply, leaves others blank):
+## $env:BIOS_AdminPassword        - Current BIOS admin password. Required to apply settings on most platforms. Empty = none set.
+## $env:BIOS_AdminPasswordNew     - New BIOS admin password to set. Empty = don't change.
+## $env:BIOS_TPMEnabled           - "Enabled" / "Disabled"
+## $env:BIOS_TPMActivation        - "Activated" / "Deactivated"
+## $env:BIOS_SecureBoot           - "Enabled" / "Disabled"
+## $env:BIOS_VirtualizationCPU    - "Enabled" / "Disabled"
+## $env:BIOS_VirtualizationIOMMU  - "Enabled" / "Disabled"
+## $env:BIOS_WakeOnLAN            - "Enabled" / "Disabled" / "LANOnly" / "LANWLAN"
+## $env:BIOS_BootMode             - "UEFI" / "Legacy"
+
+$ScriptLogName = "dell-configure.log"
+
+# --- Inlined helpers -----------------------------------------------------
+# This script is self-contained. The helpers below are duplicated across
+# Dell leaf scripts intentionally. See CLAUDE.md "OEM Vendor Scripts" for
+# the trade-off rationale.
+
+function Test-DellHardware {
+    $manufacturer = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Manufacturer
+    return ($manufacturer -like "Dell*")
+}
+
+function Get-DellInstalledModel {
+    return (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Model
+}
+
+# Dell BIOS settings translation table. Maps canonical $env:BIOS_* names to
+# Dell Command Configure (cctk.exe) argument syntax.
+#
+# Descriptor shape:
+#   @{
+#       Native = '<cctk subcommand or option name>'
+#       Values = @{ <CanonicalValue> = '<cctk value>' ; ... }
+#       Form   = 'KeyValue' | 'Subcommand'
+#   }
+#
+# Form='KeyValue'   emits  --<Native>=<value>             (e.g. --tpm=on)
+# Form='Subcommand' emits  <Native> --<Param>=<value>     (e.g. bootorder --activebootlist=uefi)
+#
+# Settings Dell does not support (or that we have not validated) are absent.
+# Unknown canonical names are logged and skipped so forward-looking vars
+# don't break the run.
+$dellBiosSettingsMap = @{
+    BIOS_TPMEnabled = @{
+        Native = 'tpm'
+        Values = @{ Enabled = 'on'; Disabled = 'off' }
+        Form   = 'KeyValue'
+    }
+    BIOS_TPMActivation = @{
+        Native = 'tpmactivation'
+        Values = @{ Activated = 'activate'; Deactivated = 'deactivate' }
+        Form   = 'KeyValue'
+    }
+    BIOS_SecureBoot = @{
+        Native = 'secureboot'
+        Values = @{ Enabled = 'enabled'; Disabled = 'disabled' }
+        Form   = 'KeyValue'
+    }
+    BIOS_VirtualizationCPU = @{
+        Native = 'virtualization'
+        Values = @{ Enabled = 'enable'; Disabled = 'disable' }
+        Form   = 'KeyValue'
+    }
+    BIOS_VirtualizationIOMMU = @{
+        Native = 'vtfordirectio'
+        Values = @{ Enabled = 'enable'; Disabled = 'disable' }
+        Form   = 'KeyValue'
+    }
+    BIOS_WakeOnLAN = @{
+        Native = 'wakeonlan'
+        Values = @{
+            Enabled  = 'lan'
+            Disabled = 'disable'
+            LANOnly  = 'lan'
+            LANWLAN  = 'lanwlan'
+        }
+        Form = 'KeyValue'
+    }
+    BIOS_BootMode = @{
+        Native = 'bootorder'
+        Values = @{ UEFI = 'uefi'; Legacy = 'legacy' }
+        Form   = 'Subcommand'
+        Param  = 'activebootlist'
+    }
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "Dell Configure"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-DellHardware)) {
+    Write-Host "Not a Dell endpoint. Skipping."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+Write-Host "Dell model: $(Get-DellInstalledModel)"
+
+# cctk.exe is installed by Dell Command Configure. Dell ships both 64-bit and 32-bit binaries.
+$cctkCandidates = @(
+    "$env:ProgramFiles\Dell\Command Configure\X86_64\cctk.exe",
+    "${env:ProgramFiles(x86)}\Dell\Command Configure\X86\cctk.exe"
+)
+$cctk = $null
+foreach ($candidate in $cctkCandidates) {
+    if (Test-Path -Path $candidate) {
+        $cctk = $candidate
+        break
+    }
+}
+
+if (-not $cctk) {
+    Write-Host "cctk.exe not found. Dell Command Configure must be installed before this script can run."
+    Write-Host "Checked: $($cctkCandidates -join '; ')"
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 2
+}
+
+Write-Host "cctk path: $cctk"
+
+# Build per-setting cctk invocations from $env:BIOS_* vars via the translation map.
+# Each setting is applied as its own cctk call so one bad value doesn't fail the
+# rest. Password flags are appended to every call when present.
+
+$passwordArgs = @()
+if (-not [string]::IsNullOrEmpty($env:BIOS_AdminPassword)) {
+    $passwordArgs += "--valsetuppwd=$env:BIOS_AdminPassword"
+}
+
+$applied = 0
+$skipped = 0
+$failed  = 0
+
+foreach ($canonical in @(
+    'BIOS_TPMEnabled',
+    'BIOS_TPMActivation',
+    'BIOS_SecureBoot',
+    'BIOS_VirtualizationCPU',
+    'BIOS_VirtualizationIOMMU',
+    'BIOS_WakeOnLAN',
+    'BIOS_BootMode'
+)) {
+    $value = (Get-Item -Path "Env:$canonical" -ErrorAction SilentlyContinue).Value
+    if ([string]::IsNullOrEmpty($value)) { continue }
+
+    if (-not $dellBiosSettingsMap.ContainsKey($canonical)) {
+        Write-Host "  $canonical=$value ... no Dell translation for this setting; skipping."
+        $skipped++
+        continue
+    }
+    $desc = $dellBiosSettingsMap[$canonical]
+
+    if (-not $desc.Values.ContainsKey($value)) {
+        Write-Host "  $canonical=$value ... value not supported by Dell (allowed: $($desc.Values.Keys -join ', ')); skipping."
+        $skipped++
+        continue
+    }
+
+    $native = $desc.Native
+    $nativeVal = $desc.Values[$value]
+
+    switch ($desc.Form) {
+        'KeyValue' {
+            $cctkArgs = @("--$native=$nativeVal") + $passwordArgs
+        }
+        'Subcommand' {
+            $cctkArgs = @($native, "--$($desc.Param)=$nativeVal") + $passwordArgs
+        }
+        default {
+            Write-Host "  $canonical ... unknown form '$($desc.Form)' in translation map; skipping."
+            $skipped++
+            continue
+        }
+    }
+
+    Write-Host "  $canonical=$value -> cctk $($cctkArgs -join ' ')"
+    try {
+        $proc = Start-Process -FilePath $cctk -ArgumentList $cctkArgs -Wait -PassThru -NoNewWindow
+        if ($proc.ExitCode -eq 0) {
+            $applied++
+        } else {
+            # TODO: Capture cctk exit codes observed during real-endpoint testing
+            # so we can map them to friendlier messages (e.g. 113 = password required).
+            Write-Host "    cctk exit code: $($proc.ExitCode)"
+            $failed++
+        }
+    } catch {
+        Write-Host "    cctk invocation threw: $_"
+        $failed++
+    }
+}
+
+# Apply admin password change last so subsequent runs use the new password.
+if (-not [string]::IsNullOrEmpty($env:BIOS_AdminPasswordNew)) {
+    Write-Host "  Setting new BIOS admin password ..."
+    $pwdArgs = @("--setuppwd=$env:BIOS_AdminPasswordNew") + $passwordArgs
+    try {
+        $proc = Start-Process -FilePath $cctk -ArgumentList $pwdArgs -Wait -PassThru -NoNewWindow
+        if ($proc.ExitCode -eq 0) {
+            Write-Host "    Admin password updated."
+            $applied++
+        } else {
+            Write-Host "    cctk setuppwd exit code: $($proc.ExitCode)"
+            $failed++
+        }
+    } catch {
+        Write-Host "    cctk setuppwd threw: $_"
+        $failed++
+    }
+}
+
+Write-Host "`nSummary: applied=$applied skipped=$skipped failed=$failed"
+
+if ($TranscriptStarted) { Stop-Transcript }
+
+if ($failed -gt 0) { exit 1 } else { exit 0 }

--- a/oem-dell/dell-debloat.ps1
+++ b/oem-dell/dell-debloat.ps1
@@ -1,0 +1,186 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                       - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description               - Ticket # or initials for audit trail
+## $env:RMMScriptPath             - Optional log directory base provided by the RMM
+
+$ScriptLogName = "dell-debloat.log"
+
+# --- Inlined helpers -----------------------------------------------------
+# This script is self-contained. The helpers below are duplicated across
+# Dell leaf scripts intentionally. See CLAUDE.md "OEM Vendor Scripts" for
+# the trade-off rationale.
+
+function Test-DellHardware {
+    $manufacturer = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue).Manufacturer
+    return ($manufacturer -like "Dell*")
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "Dell Debloat"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
+if (-not (Test-DellHardware)) {
+    Write-Host "Not a Dell endpoint. Skipping."
+    if ($TranscriptStarted) { Stop-Transcript }
+    exit 0
+}
+
+# Dell consumer software to remove. Dell Command Update and Dell Command Configure
+# are intentionally NOT in this list ... they are the vendor lifecycle tools the
+# Dell configure / DCU scripts deploy.
+$dellBloatPatterns = @(
+    "SupportAssist",
+    "Dell SupportAssist",
+    "Dell Update",
+    "Dell Mobile Connect",
+    "Dell Digital Delivery",
+    "Dell Customer Connect",
+    "Dell Help & Support",
+    "MyDell"
+)
+
+# Patterns to keep even when they match a bloat pattern by substring.
+$keepPatterns = @(
+    "Dell Command \| Update",
+    "Dell Command Update",
+    "Dell Command \| Configure",
+    "Dell Command Configure"
+)
+
+function Test-ShouldKeep {
+    param([string] $Name)
+    foreach ($keep in $keepPatterns) {
+        if ($Name -match $keep) { return $true }
+    }
+    return $false
+}
+
+# Survey both 64-bit and 32-bit uninstall hives.
+$uninstallPaths = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+
+$removedCount = 0
+$failedCount = 0
+
+foreach ($pattern in $dellBloatPatterns) {
+    $matched = foreach ($path in $uninstallPaths) {
+        Get-ItemProperty -Path $path -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -and ($_.DisplayName -match [regex]::Escape($pattern)) }
+    }
+    foreach ($app in $matched) {
+        if (Test-ShouldKeep -Name $app.DisplayName) {
+            Write-Host "Keeping: $($app.DisplayName)"
+            continue
+        }
+        Write-Host "Removing: $($app.DisplayName) [$($app.DisplayVersion)]"
+        $uninstallString = $app.UninstallString
+        if ([string]::IsNullOrEmpty($uninstallString)) {
+            Write-Host "  No uninstall string; skipping."
+            continue
+        }
+        try {
+            if ($uninstallString -match "msiexec") {
+                if ($app.PSChildName -match "^\{[0-9A-Fa-f-]+\}$") {
+                    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $($app.PSChildName) /qn /norestart" -Wait -PassThru -NoNewWindow
+                    if ($proc.ExitCode -eq 0) { $removedCount++ } else { $failedCount++; Write-Host "  msiexec exit: $($proc.ExitCode)" }
+                } else {
+                    Write-Host "  Unknown product code shape: $($app.PSChildName)"
+                    $failedCount++
+                }
+            } else {
+                $cmd = $uninstallString
+                if ($cmd -notmatch "/S" -and $cmd -notmatch "/silent" -and $cmd -notmatch "/quiet") {
+                    $cmd = "$cmd /S"
+                }
+                $proc = Start-Process -FilePath "cmd.exe" -ArgumentList "/c $cmd" -Wait -PassThru -NoNewWindow
+                if ($proc.ExitCode -eq 0) { $removedCount++ } else { $failedCount++; Write-Host "  uninstaller exit: $($proc.ExitCode)" }
+            }
+        } catch {
+            Write-Host "  Removal threw: $_"
+            $failedCount++
+        }
+    }
+}
+
+# Provisioned UWP / AppX consumer bundles ship preinstalled on Dell consumer SKUs.
+$appxPatterns = @(
+    "*DellInc.DellMobileConnect*",
+    "*DellInc.DellDigitalDelivery*",
+    "*DellInc.MyDell*",
+    "*DellInc.DellCustomerConnect*"
+)
+
+foreach ($pattern in $appxPatterns) {
+    $pkgs = Get-AppxPackage -AllUsers -Name $pattern -ErrorAction SilentlyContinue
+    foreach ($pkg in $pkgs) {
+        Write-Host "Removing AppX: $($pkg.Name)"
+        try {
+            Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop
+            $removedCount++
+        } catch {
+            Write-Host "  Remove-AppxPackage failed: $_"
+            $failedCount++
+        }
+    }
+    $provisioned = Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like $pattern.Trim('*') -or $_.PackageName -like $pattern }
+    foreach ($prov in $provisioned) {
+        Write-Host "Removing provisioned AppX: $($prov.DisplayName)"
+        try {
+            Remove-AppxProvisionedPackage -Online -PackageName $prov.PackageName -ErrorAction Stop | Out-Null
+            $removedCount++
+        } catch {
+            Write-Host "  Remove-AppxProvisionedPackage failed: $_"
+            $failedCount++
+        }
+    }
+}
+
+Write-Host "`nSummary: removed=$removedCount failed=$failedCount"
+
+if ($TranscriptStarted) { Stop-Transcript }
+
+if ($failedCount -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Summary

Replaces the now-closed #75 (foundation) and #76 (Dell with `src/` structure) with self-contained Dell OEM scripts at the repo root. Single PR against `development`.

Per the design refinement on #74: the CI fat-script build system (`src/` + `published/` branch + `# %INCLUDE` markers + GHA assembly) was overengineered for this repo's scale (~12 scripts that'd benefit from shared helpers, 5 contributors). Self-contained scripts with inlined helpers are the simpler path. ~30-50 lines duplicated across Dell + HP + Lenovo is the accepted trade.

Carried forward from the prior design (the genuinely-good parts):

- `configure` naming, not `baseline`
- `$env:BIOS_*` canonical settings with per-OEM translation tables
- Internet check at install step only (offline-safe exit 0)
- Per-OEM four-leaf shape: `*-configure.ps1` / `*-command-update-install.ps1` / `*-command-update-run.ps1` / `*-debloat.ps1`

Dropped: `src/` directory, `published` branch, `# %INCLUDE` marker syntax, GHA fat-script workflow.

## Files added

```
oem-dell/
├── dell-configure.ps1                  263 lines  (BIOS config from $env:BIOS_* env vars; inlined translation map)
├── dell-command-update-install.ps1     161 lines  (DCU install; internet-checked; inlined Test-InternetAvailable)
├── dell-command-update-run.ps1         146 lines  (DCU /scan + /applyUpdates; documented exit-code table)
└── dell-debloat.ps1                    186 lines  (uninstall SupportAssist + Dell consumer AppX; keeps Command tools)
```

Each script self-contains the helpers it needs:

- `Test-DellHardware` ... inlined into all four leaves.
- `Test-DCUInstalled` / `Get-DCUVersion` / `Get-DCUCliPath` ... inlined into `dell-command-update-install.ps1` and `dell-command-update-run.ps1`.
- `Test-InternetAvailable` ... inlined into `dell-command-update-install.ps1` only.
- `$dellBiosSettingsMap` translation table ... lives inside `dell-configure.ps1` only.

`Get-OEMManufacturer` is intentionally not used in the Dell leaves ... they each know they're Dell scripts and use the simpler `Test-DellHardware` check. HP and Lenovo will follow the same pattern.

## CLAUDE.md updates

New "OEM Vendor Scripts" section under Development Standards / Common Patterns. Covers:

- The four-leaf shape and what each leaf does
- Why `configure`, not `baseline`
- The `$env:BIOS_*` canonical settings table with per-OEM support matrix (Dell / HP / Lenovo)
- Internet check pattern (install leaves only)
- Self-contained guidance with the standard gate sequence

## TODOs captured in code

- `dell-command-update-install.ps1` ... canonical Dell-hosted DCU 5.7 installer URL. The placeholder `https://dl.dell.com/FOLDER/Dell-Command-Update-Application_WIN_5.7.0_A00.EXE` needs the real folder ID captured from a fresh manual download against https://www.dell.com/support/kbdoc/en-us/000177325/dell-command-update. The `$env:DCUInstallerURL` RMM variable overrides this, so the script ships functional even with the placeholder.
- `dell-configure.ps1` ... map cctk exit codes to friendly messages once we have real-endpoint runs (e.g. 113 = password required).
- `dell-command-update-run.ps1` ... capture any additional DCU exit codes observed in production beyond the documented 0-8 set.

No `REPLACE_WITH_REAL_HASH` placeholders ... they're gone for good. No runtime lib fetch.

## Smoke tests

PowerShell parser check on each script:

```
OK:   oem-dell\dell-configure.ps1 (263 lines)
OK:   oem-dell\dell-command-update-install.ps1 (161 lines)
OK:   oem-dell\dell-command-update-run.ps1 (146 lines)
OK:   oem-dell\dell-debloat.ps1 (186 lines)
```

Executed each script in RMM mode on a non-Dell dev workstation (iBUYPOWER). All four hit the "Not a Dell endpoint. Skipping." gate cleanly, started/stopped transcripts to `$env:RMMScriptPath\logs\`, and exited 0. Confirms:

- Three-section template structure is intact.
- `$TranscriptStarted` guard pattern (PR #34) wraps `Stop-Transcript` calls properly.
- RMM mode routing to `$env:RMMScriptPath\logs\` works.
- Manufacturer gate fires before any Dell-specific work.

Full Dell-endpoint testing (cctk invocation, DCU install/run, AppX removal) is pending against real Dell hardware. The TODOs above will be resolved as part of that pass.

## References

- Closes the redo track started in #74 (design issue; includes the refinement comment that landed on self-contained scripts).
- Supersedes #75 (foundation, closed) and #76 (Dell src/ version, closed). Branch `feature/oem-dell-redo` retained on `origin/` for cherry-pick reference.
- HP + Lenovo will follow as separate PRs once Dell is endpoint-validated, replicating this shape.

## Test plan

- [ ] Real Dell endpoint, RMM mode: `dell-configure.ps1` with `$env:BIOS_TPMEnabled=Enabled` + correct `$env:BIOS_AdminPassword`. Verify cctk exit 0 and BIOS reflects the change.
- [ ] Real Dell endpoint, no DCU installed: `dell-command-update-install.ps1` with valid `$env:DCUInstallerURL`. Verify install completes and `Get-DCUVersion` reports the target.
- [ ] Real Dell endpoint, DCU installed: `dell-command-update-run.ps1`. Verify `/scan` then `/applyUpdates` runs and exits with a documented code.
- [ ] Real Dell endpoint with consumer SKU bloat: `dell-debloat.ps1`. Verify SupportAssist + AppX removals; verify Dell Command Update and Dell Command Configure are kept.
- [ ] Offline endpoint: `dell-command-update-install.ps1`. Verify clean exit 0 with offline-skip log line.
