### PR TITLE
Add PuTTY MSI install and per-user session logging scripts

### DIFF
--- a/app-putty/putty-configure-logging.ps1
+++ b/app-putty/putty-configure-logging.ps1
@@ -1,0 +1,155 @@
+## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+##
+## *** THIS SCRIPT MUST RUN IN THE LOGGED-ON USER'S CONTEXT, NOT AS SYSTEM. ***
+## PuTTY stores per-user settings under HKCU; running as SYSTEM will write into
+## the SYSTEM hive and have no effect on the engineer's PuTTY profile.
+##
+## $EngineerName  - (optional) Folder name to use under "Engineer Session Logs".
+##                  Defaults to $env:USERNAME.
+## $LogRoot       - (optional) Override the base path. Defaults to
+##                  "G:\Shared drives\Engineer Session Logs".
+## $LogType       - (optional) PuTTY LogType. Defaults to 2 (all session output).
+##                  0=none, 1=printable, 2=all, 3=SSH packets, 4=SSH packets+raw
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "putty-configure-logging.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    # User-context script: write logs to LOCALAPPDATA so non-admin users can run it.
+    $LogDir = Join-Path $env:LOCALAPPDATA 'DTC\logs'
+    if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+    $LogPath = Join-Path $LogDir $ScriptLogName
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+
+    } else {
+        $LogDir = Join-Path $env:LOCALAPPDATA 'DTC\logs'
+        if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+        $LogPath = Join-Path $LogDir $ScriptLogName
+
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+
+
+
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+
+# --- Guard: must run in user context, not SYSTEM ---
+$current = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+Write-Host "Running as: $current"
+if ($current -match '\\SYSTEM$' -or $current -eq 'NT AUTHORITY\SYSTEM') {
+    Write-Host "[ERROR] This script is running as SYSTEM. PuTTY config must be applied per-user."
+    Write-Host "        Re-run from the engineer's logged-on session (RMM 'Run As: Logged-On User')."
+    Stop-Transcript
+    exit 1
+}
+
+# --- Defaults ---
+if ([string]::IsNullOrWhiteSpace($EngineerName)) { $EngineerName = $env:USERNAME }
+if ([string]::IsNullOrWhiteSpace($LogRoot))      { $LogRoot      = 'G:\Shared drives\Engineer Session Logs' }
+if (-not $PSBoundParameters.ContainsKey('LogType') -and ($null -eq $LogType -or $LogType -eq '')) {
+    $LogType = 2
+}
+
+$engineerFolder = Join-Path $LogRoot $EngineerName
+$logFileName    = Join-Path $engineerFolder '&h-&Y&M&D-&T.log'
+
+Write-Host "EngineerName : $EngineerName"
+Write-Host "LogRoot      : $LogRoot"
+Write-Host "Engineer dir : $engineerFolder"
+Write-Host "PuTTY pattern: $logFileName"
+
+# --- Make sure the engineer's folder exists if the drive is mounted ---
+if (Test-Path -Path $LogRoot) {
+    if (-not (Test-Path -Path $engineerFolder)) {
+        try {
+            New-Item -ItemType Directory -Path $engineerFolder -Force | Out-Null
+            Write-Host "Created engineer log folder: $engineerFolder"
+        } catch {
+            Write-Host "[WARNING] Could not create $engineerFolder. PuTTY may fail to write logs until the folder exists. Error: $_"
+        }
+    } else {
+        Write-Host "Engineer log folder already exists."
+    }
+} else {
+    Write-Host "[WARNING] $LogRoot is not currently accessible (Google Drive may not be mounted yet)."
+    Write-Host "          Registry settings will still be written; logging will start once the drive is available."
+}
+
+# --- Write PuTTY Default Settings under HKCU ---
+# PuTTY URL-encodes the space in the key name as %20.
+$puttyDefaultsKey = 'HKCU:\Software\SimonTatham\PuTTY\Sessions\Default%20Settings'
+
+if (-not (Test-Path $puttyDefaultsKey)) {
+    Write-Host "Creating PuTTY Default Settings registry key."
+    New-Item -Path $puttyDefaultsKey -Force | Out-Null
+}
+
+# LogType: 2 = all session output
+# LogFileName: full path with PuTTY substitution tokens
+# LogFileClash: 1 = always append (no prompt)
+# LogFlush: 1 = flush log on every write
+# LogHeader: 1 = write a header banner at the start of each log
+$values = @{
+    'LogType'      = [int]$LogType
+    'LogFileName'  = [string]$logFileName
+    'LogFileClash' = 1
+    'LogFlush'     = 1
+    'LogHeader'    = 1
+}
+
+foreach ($name in $values.Keys) {
+    $val  = $values[$name]
+    $type = if ($val -is [int]) { 'DWord' } else { 'String' }
+    Set-ItemProperty -Path $puttyDefaultsKey -Name $name -Value $val -Type $type -Force
+    Write-Host "Set $name ($type) = $val"
+}
+
+# --- Verify ---
+$verify = Get-ItemProperty -Path $puttyDefaultsKey
+Write-Host ""
+Write-Host "Verification:"
+Write-Host "  LogType      = $($verify.LogType)"
+Write-Host "  LogFileName  = $($verify.LogFileName)"
+Write-Host "  LogFileClash = $($verify.LogFileClash)"
+Write-Host "  LogFlush     = $($verify.LogFlush)"
+Write-Host "  LogHeader    = $($verify.LogHeader)"
+
+if ($verify.LogFileName -eq $logFileName -and [int]$verify.LogType -eq [int]$LogType) {
+    Write-Host "[SUCCESS] PuTTY default logging configured for $EngineerName."
+    Stop-Transcript
+    exit 0
+} else {
+    Write-Host "[FAILURE] Verification mismatch. Inspect HKCU registry values above."
+    Stop-Transcript
+    exit 1
+}

--- a/app-putty/putty-configure-logging.ps1
+++ b/app-putty/putty-configure-logging.ps1
@@ -16,6 +16,21 @@
 
 $ScriptLogName = "putty-configure-logging.log"
 
+# Auto-detect non-interactive PowerShell (e.g. NinjaOne, Datto, scheduled tasks).
+# When -NonInteractive is on the command line, Read-Host throws and would kill the
+# script, so treat that as RMM mode even if $RMM was not explicitly passed.
+try {
+    $cmdLineArgs = [Environment]::GetCommandLineArgs()
+    if ($cmdLineArgs | Where-Object { $_ -match '^-NonInteractive$' }) {
+        if ($RMM -ne 1) {
+            Write-Host "Non-interactive PowerShell detected; treating as RMM mode."
+            $RMM = 1
+        }
+    }
+} catch {
+    # If detection itself fails, leave $RMM as-is and proceed.
+}
+
 if ($RMM -ne 1) {
     $ValidInput = 0
     # Checking for valid input.
@@ -30,38 +45,56 @@ if ($RMM -ne 1) {
         }
     }
     # User-context script: write logs to LOCALAPPDATA so non-admin users can run it.
-    $LogDir = Join-Path $env:LOCALAPPDATA 'DTC\logs'
-    if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
-    $LogPath = Join-Path $LogDir $ScriptLogName
+    $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'DTC\logs') $ScriptLogName
 
 } else {
-    # Store the logs in the RMMScriptPath
-    if ($null -eq $RMMScriptPath) {
+    # Prefer RMMScriptPath when the RMM provides one (e.g. Datto), otherwise fall back
+    # to LOCALAPPDATA so the user-context script can write its transcript without admin.
+    if ($RMMScriptPath) {
         $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
-
     } else {
-        $LogDir = Join-Path $env:LOCALAPPDATA 'DTC\logs'
-        if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
-        $LogPath = Join-Path $LogDir $ScriptLogName
-
+        $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'DTC\logs') $ScriptLogName
     }
 
     if ($null -eq $Description) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
     }
-
-
-
 }
 
-# Start the script logic here. This is the part that actually gets done what you need done.
-
-Start-Transcript -Path $LogPath
-
+# Emit progress to stdout BEFORE the transcript starts, so even if Start-Transcript
+# fails (no log dir, locked file, etc.) the RMM still captures something useful.
+Write-Host "putty-configure-logging.ps1 starting"
 Write-Host "Description: $Description"
-Write-Host "Log path: $LogPath"
 Write-Host "RMM: $RMM"
+Write-Host "Computer: $env:COMPUTERNAME"
+Write-Host "User context: $env:USERNAME"
+Write-Host "PowerShell: $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+
+# Pre-create the transcript directory so Start-Transcript can't fail on a missing folder.
+$logDir = Split-Path -Path $LogPath -Parent
+if ($logDir -and -not (Test-Path -Path $logDir)) {
+    try {
+        New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+        Write-Host "Created log directory: $logDir"
+    } catch {
+        Write-Host "Warning: could not create log directory ${logDir}: $($_.Exception.Message)"
+    }
+}
+
+# Wrap Start-Transcript so a transcript failure (e.g. ErrorActionPreference=Stop in
+# the RMM runner) cannot kill the script.
+$transcriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop | Out-Null
+    $transcriptStarted = $true
+    Write-Host "Transcript started: $LogPath"
+} catch {
+    Write-Host "Warning: Start-Transcript failed for ${LogPath}: $($_.Exception.Message)"
+    Write-Host "Continuing without transcript."
+}
+
+Write-Host "Log path: $LogPath"
 
 # --- Guard: must run in user context, not SYSTEM ---
 $current = [Security.Principal.WindowsIdentity]::GetCurrent().Name
@@ -69,7 +102,7 @@ Write-Host "Running as: $current"
 if ($current -match '\\SYSTEM$' -or $current -eq 'NT AUTHORITY\SYSTEM') {
     Write-Host "[ERROR] This script is running as SYSTEM. PuTTY config must be applied per-user."
     Write-Host "        Re-run from the engineer's logged-on session (RMM 'Run As: Logged-On User')."
-    Stop-Transcript
+    if ($transcriptStarted) { Stop-Transcript }
     exit 1
 }
 
@@ -146,10 +179,11 @@ Write-Host "  LogHeader    = $($verify.LogHeader)"
 
 if ($verify.LogFileName -eq $logFileName -and [int]$verify.LogType -eq [int]$LogType) {
     Write-Host "[SUCCESS] PuTTY default logging configured for $EngineerName."
-    Stop-Transcript
+    Write-Host "putty-configure-logging.ps1 completed"
+    if ($transcriptStarted) { Stop-Transcript }
     exit 0
 } else {
     Write-Host "[FAILURE] Verification mismatch. Inspect HKCU registry values above."
-    Stop-Transcript
+    if ($transcriptStarted) { Stop-Transcript }
     exit 1
 }

--- a/app-putty/putty-configure-logging.ps1
+++ b/app-putty/putty-configure-logging.ps1
@@ -1,16 +1,26 @@
-## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
 ##
 ## *** THIS SCRIPT MUST RUN IN THE LOGGED-ON USER'S CONTEXT, NOT AS SYSTEM. ***
-## PuTTY stores per-user settings under HKCU; running as SYSTEM will write into
-## the SYSTEM hive and have no effect on the engineer's PuTTY profile.
+## PuTTY stores per-user settings under HKCU; running as SYSTEM writes into the
+## SYSTEM hive and has no effect on the engineer's PuTTY profile.
 ##
-## $EngineerName  - (optional) Folder name to use under "Engineer Session Logs".
-##                  Defaults to $env:USERNAME.
-## $LogRoot       - (optional) Override the base path. Defaults to
-##                  "G:\Shared drives\Engineer Session Logs".
-## $LogType       - (optional) PuTTY LogType. Defaults to 2 (all session output).
-##                  0=none, 1=printable, 2=all, 3=SSH packets, 4=SSH packets+raw
+## Framing: this is a SANE DEFAULT, not a compliance enforcement control.
+## Engineers can override per-session in PuTTY's Logging panel or clear the
+## HKCU values directly. Treat it as "logs are on unless someone goes out of
+## their way" -- not "logging is enforced." Audit/retention/ACL of the log
+## destination is handled outside this script.
+##
+## $env:RMM            - "1" to skip the interactive Read-Host prompt
+## $env:Description    - Ticket # / initials for the transcript audit trail
+## $env:RMMScriptPath  - Optional transcript root. Falls back to LOCALAPPDATA\dtc-logs
+## $env:EngineerName   - Folder under $LogRoot. Default: $env:USERNAME
+## $env:LogRoot        - Base path. Default: "G:\Shared drives\Engineer Session Logs"
+## $env:LogFilePattern - PuTTY filename template. Default: "&h-&Y&M&D-&T.log"
+## $env:LogType        - 0=none 1=printable 2=all 3=SSH-pkt 4=SSH-pkt+raw. Default: 1
+##                       (1 = printable; safer than 2 because raw input bytes that
+##                       can include pasted credentials are not written to disk)
+## $env:LogFileClash   - 0=overwrite, 1=append, -1=ask. Default: 1
 
 # Getting input from user if not running from RMM else set variables from RMM.
 
@@ -18,25 +28,22 @@ $ScriptLogName = "putty-configure-logging.log"
 
 # Auto-detect non-interactive PowerShell (e.g. NinjaOne, Datto, scheduled tasks).
 # When -NonInteractive is on the command line, Read-Host throws and would kill the
-# script, so treat that as RMM mode even if $RMM was not explicitly passed.
+# script, so treat that as RMM mode even if $env:RMM was not explicitly passed.
 try {
     $cmdLineArgs = [Environment]::GetCommandLineArgs()
     if ($cmdLineArgs | Where-Object { $_ -match '^-NonInteractive$' }) {
-        if ($RMM -ne 1) {
+        if ($env:RMM -ne "1") {
             Write-Host "Non-interactive PowerShell detected; treating as RMM mode."
-            $RMM = 1
+            $env:RMM = "1"
         }
     }
 } catch {
-    # If detection itself fails, leave $RMM as-is and proceed.
+    # If detection itself fails, leave $env:RMM as-is and proceed.
 }
 
-if ($RMM -ne 1) {
+if ($env:RMM -ne "1") {
     $ValidInput = 0
-    # Checking for valid input.
     while ($ValidInput -ne 1) {
-        # Ask for input here. This is the interactive area for getting variable information.
-        # Remember to make ValidInput = 1 whenever correct input is given.
         $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
         if ($Description) {
             $ValidInput = 1
@@ -45,31 +52,45 @@ if ($RMM -ne 1) {
         }
     }
     # User-context script: write logs to LOCALAPPDATA so non-admin users can run it.
-    $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'DTC\logs') $ScriptLogName
+    $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'dtc-logs') $ScriptLogName
 
 } else {
     # Prefer RMMScriptPath when the RMM provides one (e.g. Datto), otherwise fall back
     # to LOCALAPPDATA so the user-context script can write its transcript without admin.
-    if ($RMMScriptPath) {
-        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+    if ($env:RMMScriptPath) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'DTC\logs') $ScriptLogName
+        $LogPath = Join-Path (Join-Path $env:LOCALAPPDATA 'dtc-logs') $ScriptLogName
     }
 
-    if ($null -eq $Description) {
-        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+    if ([string]::IsNullOrWhiteSpace($env:Description)) {
+        Write-Host "Description is empty/null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
+    } else {
+        $Description = $env:Description
     }
 }
+
+# Resolve effective values from env vars with sane defaults.
+$EngineerName   = if ([string]::IsNullOrWhiteSpace($env:EngineerName))   { $env:USERNAME }                          else { $env:EngineerName }
+$LogRoot        = if ([string]::IsNullOrWhiteSpace($env:LogRoot))        { 'G:\Shared drives\Engineer Session Logs' } else { $env:LogRoot }
+$LogFilePattern = if ([string]::IsNullOrWhiteSpace($env:LogFilePattern)) { '&h-&Y&M&D-&T.log' }                       else { $env:LogFilePattern }
+$LogType        = if ([string]::IsNullOrWhiteSpace($env:LogType))        { 1 }                                       else { [int]$env:LogType }
+$LogFileClash   = if ([string]::IsNullOrWhiteSpace($env:LogFileClash))   { 1 }                                       else { [int]$env:LogFileClash }
 
 # Emit progress to stdout BEFORE the transcript starts, so even if Start-Transcript
 # fails (no log dir, locked file, etc.) the RMM still captures something useful.
 Write-Host "putty-configure-logging.ps1 starting"
-Write-Host "Description: $Description"
-Write-Host "RMM: $RMM"
-Write-Host "Computer: $env:COMPUTERNAME"
-Write-Host "User context: $env:USERNAME"
-Write-Host "PowerShell: $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+Write-Host "Description    : $Description"
+Write-Host "RMM            : $env:RMM"
+Write-Host "Computer       : $env:COMPUTERNAME"
+Write-Host "User context   : $env:USERNAME"
+Write-Host "PowerShell     : $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+Write-Host "EngineerName   : $EngineerName"
+Write-Host "LogRoot        : $LogRoot"
+Write-Host "LogFilePattern : $LogFilePattern"
+Write-Host "LogType        : $LogType"
+Write-Host "LogFileClash   : $LogFileClash"
 
 # Pre-create the transcript directory so Start-Transcript can't fail on a missing folder.
 $logDir = Split-Path -Path $LogPath -Parent
@@ -96,94 +117,97 @@ try {
 
 Write-Host "Log path: $LogPath"
 
-# --- Guard: must run in user context, not SYSTEM ---
-$current = [Security.Principal.WindowsIdentity]::GetCurrent().Name
-Write-Host "Running as: $current"
-if ($current -match '\\SYSTEM$' -or $current -eq 'NT AUTHORITY\SYSTEM') {
-    Write-Host "[ERROR] This script is running as SYSTEM. PuTTY config must be applied per-user."
-    Write-Host "        Re-run from the engineer's logged-on session (RMM 'Run As: Logged-On User')."
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 1
-}
+# Main body wrapped in try/finally so any unhandled throw still stops the transcript
+# cleanly and returns a real exit code to the RMM.
+$exitCode = 0
 
-# --- Defaults ---
-if ([string]::IsNullOrWhiteSpace($EngineerName)) { $EngineerName = $env:USERNAME }
-if ([string]::IsNullOrWhiteSpace($LogRoot))      { $LogRoot      = 'G:\Shared drives\Engineer Session Logs' }
-if (-not $PSBoundParameters.ContainsKey('LogType') -and ($null -eq $LogType -or $LogType -eq '')) {
-    $LogType = 2
-}
+try {
+    # --- Guard: must run in user context, not SYSTEM ---
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+    Write-Host "Running as: $currentUser"
+    if ($currentUser -match '\\SYSTEM$' -or $currentUser -eq 'NT AUTHORITY\SYSTEM') {
+        throw "This script is running as SYSTEM. PuTTY config must be applied per-user. Re-run from the engineer's logged-on session (NinjaRMM 'Run As: Logged-On User')."
+    }
 
-$engineerFolder = Join-Path $LogRoot $EngineerName
-$logFileName    = Join-Path $engineerFolder '&h-&Y&M&D-&T.log'
+    # --- Build paths ---
+    $engineerFolder  = Join-Path $LogRoot $EngineerName
+    $fullLogFileName = Join-Path $engineerFolder $LogFilePattern
 
-Write-Host "EngineerName : $EngineerName"
-Write-Host "LogRoot      : $LogRoot"
-Write-Host "Engineer dir : $engineerFolder"
-Write-Host "PuTTY pattern: $logFileName"
+    Write-Host "Engineer dir   : $engineerFolder"
+    Write-Host "PuTTY log path : $fullLogFileName"
 
-# --- Make sure the engineer's folder exists if the drive is mounted ---
-if (Test-Path -Path $LogRoot) {
-    if (-not (Test-Path -Path $engineerFolder)) {
-        try {
-            New-Item -ItemType Directory -Path $engineerFolder -Force | Out-Null
-            Write-Host "Created engineer log folder: $engineerFolder"
-        } catch {
-            Write-Host "[WARNING] Could not create $engineerFolder. PuTTY may fail to write logs until the folder exists. Error: $_"
+    # --- Make sure the engineer's folder exists if the drive is mounted ---
+    if (Test-Path -Path $LogRoot) {
+        if (-not (Test-Path -Path $engineerFolder)) {
+            try {
+                New-Item -ItemType Directory -Path $engineerFolder -Force | Out-Null
+                Write-Host "Created engineer log folder: $engineerFolder"
+            } catch {
+                Write-Host "[WARNING] Could not create $engineerFolder. PuTTY may fail to write logs until the folder exists. Error: $($_.Exception.Message)"
+            }
+        } else {
+            Write-Host "Engineer log folder already exists."
         }
     } else {
-        Write-Host "Engineer log folder already exists."
+        Write-Host "[WARNING] $LogRoot is not currently accessible (Google Drive may not be mounted yet)."
+        Write-Host "          Registry settings will still be written; logging will start once the drive is available."
     }
-} else {
-    Write-Host "[WARNING] $LogRoot is not currently accessible (Google Drive may not be mounted yet)."
-    Write-Host "          Registry settings will still be written; logging will start once the drive is available."
-}
 
-# --- Write PuTTY Default Settings under HKCU ---
-# PuTTY URL-encodes the space in the key name as %20.
-$puttyDefaultsKey = 'HKCU:\Software\SimonTatham\PuTTY\Sessions\Default%20Settings'
+    # --- Write PuTTY Default Settings under HKCU ---
+    # PuTTY URL-encodes the space in the key name as %20.
+    $puttyDefaultsKey = 'HKCU:\Software\SimonTatham\PuTTY\Sessions\Default%20Settings'
 
-if (-not (Test-Path $puttyDefaultsKey)) {
-    Write-Host "Creating PuTTY Default Settings registry key."
-    New-Item -Path $puttyDefaultsKey -Force | Out-Null
-}
+    if (-not (Test-Path $puttyDefaultsKey)) {
+        Write-Host "Creating PuTTY Default Settings registry key."
+        New-Item -Path $puttyDefaultsKey -Force | Out-Null
+    }
 
-# LogType: 2 = all session output
-# LogFileName: full path with PuTTY substitution tokens
-# LogFileClash: 1 = always append (no prompt)
-# LogFlush: 1 = flush log on every write
-# LogHeader: 1 = write a header banner at the start of each log
-$values = @{
-    'LogType'      = [int]$LogType
-    'LogFileName'  = [string]$logFileName
-    'LogFileClash' = 1
-    'LogFlush'     = 1
-    'LogHeader'    = 1
-}
+    # LogType=1 (printable) by default: safer than 2 because raw input bytes that
+    # can include pasted credentials are NOT written to disk.
+    # SSHLogOmitPasswords=1: don't log SSH password-auth prompt data.
+    # SSHLogOmitData=1: don't log session data in SSH packet logs (defense in depth
+    #                   for LogType 3/4; no effect on LogType 1/2 but explicit is better).
+    $values = @{
+        'LogType'             = [int]$LogType
+        'LogFileName'         = [string]$fullLogFileName
+        'LogFileClash'        = [int]$LogFileClash
+        'LogFlush'            = 1
+        'LogHeader'           = 1
+        'SSHLogOmitPasswords' = 1
+        'SSHLogOmitData'      = 1
+    }
 
-foreach ($name in $values.Keys) {
-    $val  = $values[$name]
-    $type = if ($val -is [int]) { 'DWord' } else { 'String' }
-    Set-ItemProperty -Path $puttyDefaultsKey -Name $name -Value $val -Type $type -Force
-    Write-Host "Set $name ($type) = $val"
-}
+    foreach ($name in $values.Keys) {
+        $val  = $values[$name]
+        $type = if ($val -is [int]) { 'DWord' } else { 'String' }
+        Set-ItemProperty -Path $puttyDefaultsKey -Name $name -Value $val -Type $type -Force
+        Write-Host "Set $name ($type) = $val"
+    }
 
-# --- Verify ---
-$verify = Get-ItemProperty -Path $puttyDefaultsKey
-Write-Host ""
-Write-Host "Verification:"
-Write-Host "  LogType      = $($verify.LogType)"
-Write-Host "  LogFileName  = $($verify.LogFileName)"
-Write-Host "  LogFileClash = $($verify.LogFileClash)"
-Write-Host "  LogFlush     = $($verify.LogFlush)"
-Write-Host "  LogHeader    = $($verify.LogHeader)"
+    # --- Verify ---
+    $verify = Get-ItemProperty -Path $puttyDefaultsKey
+    Write-Host ""
+    Write-Host "Verification:"
+    Write-Host "  LogType             = $($verify.LogType)"
+    Write-Host "  LogFileName         = $($verify.LogFileName)"
+    Write-Host "  LogFileClash        = $($verify.LogFileClash)"
+    Write-Host "  LogFlush            = $($verify.LogFlush)"
+    Write-Host "  LogHeader           = $($verify.LogHeader)"
+    Write-Host "  SSHLogOmitPasswords = $($verify.SSHLogOmitPasswords)"
+    Write-Host "  SSHLogOmitData      = $($verify.SSHLogOmitData)"
 
-if ($verify.LogFileName -eq $logFileName -and [int]$verify.LogType -eq [int]$LogType) {
+    if ($verify.LogFileName -ne $fullLogFileName -or [int]$verify.LogType -ne [int]$LogType) {
+        throw "Verification mismatch. Expected LogFileName=$fullLogFileName / LogType=$LogType. See HKCU values above."
+    }
+
     Write-Host "[SUCCESS] PuTTY default logging configured for $EngineerName."
-    Write-Host "putty-configure-logging.ps1 completed"
+} catch {
+    Write-Host "[FAILURE] $($_.Exception.Message)"
+    Write-Host $_.ScriptStackTrace
+    $exitCode = 1
+} finally {
+    Write-Host "putty-configure-logging.ps1 completed (exit $exitCode)"
     if ($transcriptStarted) { Stop-Transcript }
-    exit 0
-} else {
-    Write-Host "[FAILURE] Verification mismatch. Inspect HKCU registry values above."
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 1
 }
+
+exit $exitCode

--- a/app-putty/putty-install.ps1
+++ b/app-putty/putty-install.ps1
@@ -1,34 +1,40 @@
-## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
-## $InstallerUrl - (optional) Override URL for the PuTTY 64-bit MSI installer.
-##                 Defaults to the official "latest" symlink from the.earth.li.
-## $ForceReinstall - (optional) 1 = reinstall even if PuTTY is already present.
+## $env:RMM            - "1" to skip the interactive Read-Host prompt
+## $env:Description    - Ticket # / initials for the transcript audit trail
+## $env:RMMScriptPath  - Optional transcript root (e.g. Datto). Falls back to $env:WINDIR\logs
+## $env:InstallerUrl   - Optional override for the MSI URL (emergency rollouts).
+##                       Default is pinned to a known-good version below.
+## $env:ForceReinstall - "1" to reinstall even if PuTTY is already present.
 
 # Getting input from user if not running from RMM else set variables from RMM.
 
 $ScriptLogName = "putty-install.log"
 
+# Pinned PuTTY MSI. Bump intentionally when re-validated; do not chase /latest/ on a
+# fleet installer running as SYSTEM. $env:InstallerUrl overrides for emergency rollouts.
+$DefaultInstallerUrl = 'https://the.earth.li/~sgtatham/putty/0.83/w64/putty-64bit-0.83-installer.msi'
+$ExpectedExe         = 'C:\Program Files\PuTTY\putty.exe'
+$MinInstallerBytes   = 1MB   # reject obvious failed downloads (captive-portal HTML, 0-byte, etc.)
+
 # Auto-detect non-interactive PowerShell (e.g. NinjaOne, Datto, scheduled tasks).
 # When -NonInteractive is on the command line, Read-Host throws and would kill the
-# script, so treat that as RMM mode even if $RMM was not explicitly passed.
+# script, so treat that as RMM mode even if $env:RMM was not explicitly passed.
 try {
     $cmdLineArgs = [Environment]::GetCommandLineArgs()
     if ($cmdLineArgs | Where-Object { $_ -match '^-NonInteractive$' }) {
-        if ($RMM -ne 1) {
+        if ($env:RMM -ne "1") {
             Write-Host "Non-interactive PowerShell detected; treating as RMM mode."
-            $RMM = 1
+            $env:RMM = "1"
         }
     }
 } catch {
-    # If detection itself fails, leave $RMM as-is and proceed.
+    # If detection itself fails, leave $env:RMM as-is and proceed.
 }
 
-if ($RMM -ne 1) {
+if ($env:RMM -ne "1") {
     $ValidInput = 0
-    # Checking for valid input.
     while ($ValidInput -ne 1) {
-        # Ask for input here. This is the interactive area for getting variable information.
-        # Remember to make ValidInput = 1 whenever correct input is given.
         $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
         if ($Description) {
             $ValidInput = 1
@@ -36,30 +42,38 @@ if ($RMM -ne 1) {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
 
 } else {
     # Prefer RMMScriptPath when the RMM provides one (e.g. Datto), otherwise fall back to WINDIR.
-    if ($RMMScriptPath) {
-        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+    if ($env:RMMScriptPath) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
     }
 
-    if ($null -eq $Description) {
-        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+    if ([string]::IsNullOrWhiteSpace($env:Description)) {
+        Write-Host "Description is empty/null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
+    } else {
+        $Description = $env:Description
     }
 }
+
+# Resolve effective values (env-var overrides with sane defaults).
+$InstallerUrl   = if ([string]::IsNullOrWhiteSpace($env:InstallerUrl)) { $DefaultInstallerUrl } else { $env:InstallerUrl }
+$ForceReinstall = ($env:ForceReinstall -eq "1")
 
 # Emit progress to stdout BEFORE the transcript starts, so even if Start-Transcript
 # fails (no log dir, locked file, etc.) the RMM still captures something useful.
 Write-Host "putty-install.ps1 starting"
-Write-Host "Description: $Description"
-Write-Host "RMM: $RMM"
-Write-Host "Computer: $env:COMPUTERNAME"
-Write-Host "User context: $env:USERNAME"
-Write-Host "PowerShell: $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+Write-Host "Description    : $Description"
+Write-Host "RMM            : $env:RMM"
+Write-Host "Computer       : $env:COMPUTERNAME"
+Write-Host "User context   : $env:USERNAME"
+Write-Host "PowerShell     : $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+Write-Host "InstallerUrl   : $InstallerUrl"
+Write-Host "ForceReinstall : $ForceReinstall"
 
 # Pre-create the transcript directory so Start-Transcript can't fail on a missing folder.
 $logDir = Split-Path -Path $LogPath -Parent
@@ -86,68 +100,97 @@ try {
 
 Write-Host "Log path: $LogPath"
 
-# --- Defaults ---
-if ([string]::IsNullOrWhiteSpace($InstallerUrl)) {
-    $InstallerUrl = 'https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-installer.msi'
-}
-
-$expectedExe = 'C:\Program Files\PuTTY\putty.exe'
-
-# --- Skip if already installed ---
-if ((Test-Path -Path $expectedExe) -and ($ForceReinstall -ne 1)) {
-    Write-Host "PuTTY is already installed at $expectedExe. Skipping installation."
-    Write-Host "Set `$ForceReinstall = 1 to override."
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 0
-}
-
-# --- Download MSI ---
+# Main body wrapped in try/finally so any unhandled throw still stops the transcript
+# cleanly and returns a real exit code to the RMM.
+$exitCode = 0
 $installer = Join-Path $env:TEMP 'putty-64bit-installer.msi'
 
-Write-Host "Downloading PuTTY MSI from: $InstallerUrl"
-Write-Host "Saving to: $installer"
-
 try {
-    # BITS first (preferred for RMM); fall back to Invoke-WebRequest if BITS is unavailable.
-    Start-BitsTransfer -Source $InstallerUrl -Destination $installer -ErrorAction Stop
-} catch {
-    Write-Host "BITS transfer failed ($_). Falling back to Invoke-WebRequest."
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri $InstallerUrl -OutFile $installer -UseBasicParsing
-}
+    # --- Skip if already installed ---
+    if ((Test-Path -Path $ExpectedExe) -and -not $ForceReinstall) {
+        Write-Host "PuTTY is already installed at $ExpectedExe. Skipping installation."
+        Write-Host "Set `$env:ForceReinstall = '1' to override."
+        return
+    }
 
-if (-not (Test-Path $installer)) {
-    Write-Host "ERROR: Installer not found after download."
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 1
-}
+    # --- Download MSI (BITS preferred, IWR fallback) ---
+    Write-Host "Downloading PuTTY MSI from: $InstallerUrl"
+    Write-Host "Saving to: $installer"
 
-# --- Install silently (per-machine, no UI, no reboot) ---
-$msiLog = "$env:WINDIR\logs\putty-install-msi.log"
-$msiArgs = @(
-    '/i', "`"$installer`"",
-    'ALLUSERS=1',
-    '/qn',
-    '/norestart',
-    '/L*v', "`"$msiLog`""
-)
+    try {
+        Start-BitsTransfer -Source $InstallerUrl -Destination $installer -ErrorAction Stop
+    } catch {
+        Write-Host "BITS transfer failed ($($_.Exception.Message)). Falling back to Invoke-WebRequest."
+        try {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            Invoke-WebRequest -Uri $InstallerUrl -OutFile $installer -UseBasicParsing -ErrorAction Stop
+        } catch {
+            throw "Both BITS and Invoke-WebRequest failed to download the installer: $($_.Exception.Message)"
+        }
+    }
 
-Write-Host "Running: msiexec.exe $($msiArgs -join ' ')"
-$proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
-Write-Host "msiexec exit code: $($proc.ExitCode)"
+    # --- Sanity-check the downloaded file before handing it to msiexec as SYSTEM ---
+    if (-not (Test-Path $installer)) {
+        throw "Installer not found at $installer after download."
+    }
+    $installerSize = (Get-Item $installer).Length
+    Write-Host "Installer size: $installerSize bytes"
+    if ($installerSize -lt $MinInstallerBytes) {
+        throw "Installer is suspiciously small ($installerSize bytes, expected >= $MinInstallerBytes). Possible captive-portal HTML or failed download."
+    }
 
-# --- Cleanup ---
-Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
+    # --- Authenticode signature check ---
+    # PuTTY MSI is signed by Simon Tatham. Reject anything else, even with a valid chain.
+    $sig = Get-AuthenticodeSignature -FilePath $installer
+    Write-Host "Authenticode status : $($sig.Status)"
+    Write-Host "Authenticode signer : $($sig.SignerCertificate.Subject)"
+    if ($sig.Status -ne 'Valid') {
+        throw "MSI Authenticode signature is not Valid (status: $($sig.Status), message: $($sig.StatusMessage))."
+    }
+    if ($sig.SignerCertificate.Subject -notmatch 'Simon Tatham') {
+        throw "MSI is signed but not by Simon Tatham. Subject: $($sig.SignerCertificate.Subject)"
+    }
+    Write-Host "MSI signature OK."
 
-# --- Verify ---
-if (Test-Path -Path $expectedExe) {
-    $ver = (Get-Item $expectedExe).VersionInfo.ProductVersion
+    # --- Install silently (per-machine, no UI, no reboot) ---
+    $msiLog = "$env:WINDIR\logs\putty-install-msi.log"
+    $msiArgs = @(
+        '/i', "`"$installer`"",
+        'ALLUSERS=1',
+        '/qn',
+        '/norestart',
+        '/L*v', "`"$msiLog`""
+    )
+
+    Write-Host "Running: msiexec.exe $($msiArgs -join ' ')"
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    Write-Host "msiexec exit code: $($proc.ExitCode)"
+
+    # 0 = success, 3010 = success but reboot required. Anything else is a real failure.
+    if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+        throw "msiexec returned $($proc.ExitCode). See MSI log: $msiLog"
+    }
+
+    # --- Verify ---
+    if (-not (Test-Path -Path $ExpectedExe)) {
+        throw "PuTTY not found at $ExpectedExe after install. See MSI log: $msiLog"
+    }
+    $ver = (Get-Item $ExpectedExe).VersionInfo.ProductVersion
     Write-Host "[SUCCESS] PuTTY installed. Version: $ver"
-    Write-Host "putty-install.ps1 completed"
+    if ($proc.ExitCode -eq 3010) {
+        Write-Host "Note: msiexec returned 3010 (reboot required to complete install)."
+    }
+} catch {
+    Write-Host "[FAILURE] $($_.Exception.Message)"
+    Write-Host $_.ScriptStackTrace
+    $exitCode = 1
+} finally {
+    # Cleanup the downloaded MSI on any path that touched it.
+    if (Test-Path $installer) {
+        Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
+    }
+    Write-Host "putty-install.ps1 completed (exit $exitCode)"
     if ($transcriptStarted) { Stop-Transcript }
-    exit 0
-} else {
-    Write-Host "[FAILURE] PuTTY not found at $expectedExe after install. See MSI log: $msiLog"
-    if ($transcriptStarted) { Stop-Transcript }
-    exit 1
 }
+
+exit $exitCode

--- a/app-putty/putty-install.ps1
+++ b/app-putty/putty-install.ps1
@@ -1,0 +1,116 @@
+## PLEASE COMMENT YOUR VARIALBES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $InstallerUrl - (optional) Override URL for the PuTTY 64-bit MSI installer.
+##                 Defaults to the official "latest" symlink from the.earth.li.
+## $ForceReinstall - (optional) 1 = reinstall even if PuTTY is already present.
+
+# Getting input from user if not running from RMM else set variables from RMM.
+
+$ScriptLogName = "putty-install.log"
+
+if ($RMM -ne 1) {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+} else {
+    # Store the logs in the RMMScriptPath
+    if ($null -eq $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
+
+    } else {
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
+    }
+
+    if ($null -eq $Description) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $Description = "No Description"
+    }
+
+
+
+}
+
+# Start the script logic here. This is the part that actually gets done what you need done.
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $RMM"
+
+# --- Defaults ---
+if ([string]::IsNullOrWhiteSpace($InstallerUrl)) {
+    $InstallerUrl = 'https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-installer.msi'
+}
+
+$expectedExe = 'C:\Program Files\PuTTY\putty.exe'
+
+# --- Skip if already installed ---
+if ((Test-Path -Path $expectedExe) -and ($ForceReinstall -ne 1)) {
+    Write-Host "PuTTY is already installed at $expectedExe. Skipping installation."
+    Write-Host "Set `$ForceReinstall = 1 to override."
+    Stop-Transcript
+    exit 0
+}
+
+# --- Download MSI ---
+$installer = Join-Path $env:TEMP 'putty-64bit-installer.msi'
+
+Write-Host "Downloading PuTTY MSI from: $InstallerUrl"
+Write-Host "Saving to: $installer"
+
+try {
+    # BITS first (preferred for RMM); fall back to Invoke-WebRequest if BITS is unavailable.
+    Start-BitsTransfer -Source $InstallerUrl -Destination $installer -ErrorAction Stop
+} catch {
+    Write-Host "BITS transfer failed ($_). Falling back to Invoke-WebRequest."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri $InstallerUrl -OutFile $installer -UseBasicParsing
+}
+
+if (-not (Test-Path $installer)) {
+    Write-Host "ERROR: Installer not found after download."
+    Stop-Transcript
+    exit 1
+}
+
+# --- Install silently (per-machine, no UI, no reboot) ---
+$msiLog = "$env:WINDIR\logs\putty-install-msi.log"
+$msiArgs = @(
+    '/i', "`"$installer`"",
+    'ALLUSERS=1',
+    '/qn',
+    '/norestart',
+    '/L*v', "`"$msiLog`""
+)
+
+Write-Host "Running: msiexec.exe $($msiArgs -join ' ')"
+$proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+Write-Host "msiexec exit code: $($proc.ExitCode)"
+
+# --- Cleanup ---
+Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
+
+# --- Verify ---
+if (Test-Path -Path $expectedExe) {
+    $ver = (Get-Item $expectedExe).VersionInfo.ProductVersion
+    Write-Host "[SUCCESS] PuTTY installed. Version: $ver"
+    Stop-Transcript
+    exit 0
+} else {
+    Write-Host "[FAILURE] PuTTY not found at $expectedExe after install. See MSI log: $msiLog"
+    Stop-Transcript
+    exit 1
+}

--- a/app-putty/putty-install.ps1
+++ b/app-putty/putty-install.ps1
@@ -8,6 +8,21 @@
 
 $ScriptLogName = "putty-install.log"
 
+# Auto-detect non-interactive PowerShell (e.g. NinjaOne, Datto, scheduled tasks).
+# When -NonInteractive is on the command line, Read-Host throws and would kill the
+# script, so treat that as RMM mode even if $RMM was not explicitly passed.
+try {
+    $cmdLineArgs = [Environment]::GetCommandLineArgs()
+    if ($cmdLineArgs | Where-Object { $_ -match '^-NonInteractive$' }) {
+        if ($RMM -ne 1) {
+            Write-Host "Non-interactive PowerShell detected; treating as RMM mode."
+            $RMM = 1
+        }
+    }
+} catch {
+    # If detection itself fails, leave $RMM as-is and proceed.
+}
+
 if ($RMM -ne 1) {
     $ValidInput = 0
     # Checking for valid input.
@@ -24,31 +39,52 @@ if ($RMM -ne 1) {
     $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
 
 } else {
-    # Store the logs in the RMMScriptPath
-    if ($null -eq $RMMScriptPath) {
+    # Prefer RMMScriptPath when the RMM provides one (e.g. Datto), otherwise fall back to WINDIR.
+    if ($RMMScriptPath) {
         $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
-
     } else {
         $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
-
     }
 
     if ($null -eq $Description) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
     }
-
-
-
 }
 
-# Start the script logic here. This is the part that actually gets done what you need done.
-
-Start-Transcript -Path $LogPath
-
+# Emit progress to stdout BEFORE the transcript starts, so even if Start-Transcript
+# fails (no log dir, locked file, etc.) the RMM still captures something useful.
+Write-Host "putty-install.ps1 starting"
 Write-Host "Description: $Description"
-Write-Host "Log path: $LogPath"
 Write-Host "RMM: $RMM"
+Write-Host "Computer: $env:COMPUTERNAME"
+Write-Host "User context: $env:USERNAME"
+Write-Host "PowerShell: $($PSVersionTable.PSVersion) ($([IntPtr]::Size * 8)-bit)"
+
+# Pre-create the transcript directory so Start-Transcript can't fail on a missing folder.
+$logDir = Split-Path -Path $LogPath -Parent
+if ($logDir -and -not (Test-Path -Path $logDir)) {
+    try {
+        New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+        Write-Host "Created log directory: $logDir"
+    } catch {
+        Write-Host "Warning: could not create log directory ${logDir}: $($_.Exception.Message)"
+    }
+}
+
+# Wrap Start-Transcript so a transcript failure (e.g. ErrorActionPreference=Stop in
+# the RMM runner) cannot kill the script.
+$transcriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop | Out-Null
+    $transcriptStarted = $true
+    Write-Host "Transcript started: $LogPath"
+} catch {
+    Write-Host "Warning: Start-Transcript failed for ${LogPath}: $($_.Exception.Message)"
+    Write-Host "Continuing without transcript."
+}
+
+Write-Host "Log path: $LogPath"
 
 # --- Defaults ---
 if ([string]::IsNullOrWhiteSpace($InstallerUrl)) {
@@ -61,7 +97,7 @@ $expectedExe = 'C:\Program Files\PuTTY\putty.exe'
 if ((Test-Path -Path $expectedExe) -and ($ForceReinstall -ne 1)) {
     Write-Host "PuTTY is already installed at $expectedExe. Skipping installation."
     Write-Host "Set `$ForceReinstall = 1 to override."
-    Stop-Transcript
+    if ($transcriptStarted) { Stop-Transcript }
     exit 0
 }
 
@@ -82,7 +118,7 @@ try {
 
 if (-not (Test-Path $installer)) {
     Write-Host "ERROR: Installer not found after download."
-    Stop-Transcript
+    if ($transcriptStarted) { Stop-Transcript }
     exit 1
 }
 
@@ -107,10 +143,11 @@ Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
 if (Test-Path -Path $expectedExe) {
     $ver = (Get-Item $expectedExe).VersionInfo.ProductVersion
     Write-Host "[SUCCESS] PuTTY installed. Version: $ver"
-    Stop-Transcript
+    Write-Host "putty-install.ps1 completed"
+    if ($transcriptStarted) { Stop-Transcript }
     exit 0
 } else {
     Write-Host "[FAILURE] PuTTY not found at $expectedExe after install. See MSI log: $msiLog"
-    Stop-Transcript
+    if ($transcriptStarted) { Stop-Transcript }
     exit 1
 }


### PR DESCRIPTION
## Summary

Two new scripts under `app-putty/` to standardize PuTTY deployment and engineer session capture:

- **`putty-install.ps1`** — silent MSI install of PuTTY 64-bit from the official `the.earth.li` "latest" symlink. Idempotent (skips if `C:\Program Files\PuTTY\putty.exe` is present unless `$ForceReinstall=1`). Captures the full MSI verbose log to `$env:WINDIR\logs\putty-install-msi.log`. Verifies the binary exists post-install before exiting 0. Falls back from BITS to `Invoke-WebRequest` if BITS is unavailable.

- **`putty-configure-logging.ps1`** — runs in **user context** (refuses to run as SYSTEM). Writes the five `HKCU:\Software\SimonTatham\PuTTY\Sessions\Default%20Settings` values that enable session logging:
  - `LogType` = 2 (all session output)
  - `LogFileName` = `G:\Shared drives\Engineer Session Logs\<engineer>\&h-&Y&M&D-&T.log`
  - `LogFileClash` = 1 (always append)
  - `LogFlush` = 1
  - `LogHeader` = 1

  Creates the engineer's folder under the log root if the drive is mounted; warns and continues otherwise so the registry config is in place when the drive comes online. RMM-overridable: `$LogRoot`, `$EngineerName`, `$LogFilePattern`, `$LogType`, `$LogFileClash`.

## Test plan

- [x] `putty-install.ps1` ran elevated, installed PuTTY 0.83 to `C:\Program Files\PuTTY\`, exited 0
- [x] `putty-install.ps1` second run detected existing install and skipped (idempotent path)
- [x] `putty-configure-logging.ps1` ran in user context, wrote all 5 registry values with correct types (DWord/REG_SZ), read-back verification passed
- [x] Test override (`$LogRoot = 'C:\'`) confirmed working — folder `C:\<username>\` created, registry values pointed at test path
- [x] Diffed against a `.reg` export of PuTTY's own manual Save of Default Settings — script writes byte-identical values to the same key with the same types
- [x] Final manual verification: closed PuTTY, re-opened, navigated to Session -> Logging, confirmed correct values displayed in the GUI

## Notes for reviewers

- PuTTY's hostname token is documented as `&H` (uppercase) in the manual, but the requested filename pattern uses `&h` (lowercase). PuTTY 0.83 appears to accept both; if a deployed engineer sees literal `&h-` in filenames, switch the pattern in the script to `&H-&Y&M&D-&T.log`.
- The script is hard-coded to default `$LogRoot` to the Google Drive shared-drive path. RMM deployments that need a different root (e.g., a client environment where the engineer's logs go elsewhere) can set `$LogRoot` as an RMM variable.