### PR TITLE
fix(rmm-ninja): remove stale backup.ninjarmm.com endpoint from Lockhart remediation

### DIFF
--- a/rmm-ninja/lockhart-remediation.ps1
+++ b/rmm-ninja/lockhart-remediation.ps1
@@ -257,7 +257,6 @@ $script:ParentAgentName = 'NinjaRMMAgent'
 $script:MutexName       = 'Global\DTC_NinjaOneBackup_LockhartRemediation_v8'
 $script:CloudEndpoints  = @(
     @{ Host='app.ninjarmm.com';           Port=443 },
-    @{ Host='backup.ninjarmm.com';        Port=443 },
     @{ Host='s3.amazonaws.com';           Port=443 },
     @{ Host='s3.us-east-1.amazonaws.com'; Port=443 }
 )


### PR DESCRIPTION
## Summary
Removes `backup.ninjarmm.com:443` from `$script:CloudEndpoints` in `rmm-ninja/lockhart-remediation.ps1`. That hostname is no longer used by the NinjaOne backup service.

## Problem
Because `backup.ninjarmm.com` no longer resolves, the endpoint check failed DNS + TCP on **every** run, causing two distinct defects:

1. **Unnecessary disruptive repairs** — a failed cloud endpoint triggers DNS cache flush, Dnscache service restart, and ARP cache clear (gated to off-hours, but firing for a non-issue).
2. **False-positive remediation FAILURE** — post-repair verification added the dead host to `confirmFailures` as `DNS_Still_Failing` / `Cloud_Still_Unreachable`. A nonexistent host can never resolve, so the script reported the whole remediation as failed even when Lockhart was successfully repaired.

## Fix
Remove the stale endpoint. Remaining endpoints still cover real connectivity:
- `app.ninjarmm.com` — agent control channel
- `s3.amazonaws.com`, `s3.us-east-1.amazonaws.com` — backup storage targets

## Testing
- ✅ `[System.Management.Automation.Language.Parser]::ParseFile` — no syntax errors
- ✅ Pester tests (`tests/lockhart-remediation.Tests.ps1`) do not reference the endpoint list; no test changes required
- No behavioral change beyond no longer probing the dead host

## Taxonomy
Bug — script did not do what it was designed to (reported false failure on a stale endpoint). Patch-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)