### PR TITLE
refactor(bdr-veeam): location-scoped buckets, device-OUID folders, active/inactive inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ All scripts follow a consistent three-part structure defined in `script-template
 Scripts are organized by category prefixes:
 - `app-*`: Application-specific scripts (Duo, Adobe, Teramind, etc.)
 - `bdr-*`: Backup and Disaster Recovery (Veeam, MSP360)
+- `db-*`: Database engines (MySQL, etc.)
 - `iaas-*`: Infrastructure as a Service (Azure, Backblaze, Dynu)
 - `mw-*`: Middleware/Microsoft 365 scripts
 - `msft-*`: Microsoft Windows system scripts
@@ -533,13 +534,100 @@ if ($veeamVersion -ge $requiredVersion) {
 
 ## Git Workflow
 
-**Branching Model:**
-* `development` — default branch (HEAD), active work lands here
-* `release` — stable/production branch, merged from development when ready
-* `enhancement/{name}` — branched from development for new functionality
-* `problem/{name}` — branched from development for bug fixes and issue resolution
-* No `main` or `master` branches
+See [DTC KB ... Change Taxonomy](https://kb.dtctoday.com/books/developer-operations-devops/page/change-taxonomy) for the canonical reference. This file mirrors the rules; the KB is authoritative.
 
-**GitHub Issues & Labels:**
-* New functionality uses the **enhancement** label, not "feature"
-* Configure repository labels accordingly
+**Branching Model:**
+* `main` ... default branch and release branch. Production code deployed to customer environments lives here.
+* This repo has no `development` branch. Feature/fix PRs target `main` directly.
+* All changes go through a typed branch and a pull request ... no direct commits to `main` (exception: minor `CLAUDE.md` / `README.md` doc updates that do not affect script functionality).
+
+**CRITICAL: All changes must be made in a typed branch, never directly to `main`.**
+
+### Change Taxonomy (two-tier ... Halo / GitHub / branch)
+
+Every change to this repo maps to one of four categories under two parent types. The category drives the branch prefix, the GitHub labels, and the default semver bump (future-state: this repo has no semver versioning today, but the bump column is recorded for when it does). `Refactor` spans both parent types ... see the table.
+
+| Halo Type | Halo Category | GitHub labels | Branch prefix | Default semver |
+|---|---|---|---|---|
+| `Problem` | `Bug` | `type:problem` + `category:bug` | `bug/{name}` | Patch |
+| `Problem` | `Refactor` | `type:problem` + `category:refactor` | `refactor/{name}` | Patch |
+| `Enhancement` | `Feature` | `type:enhancement` + `category:feature` | `feature/{name}` | Minor |
+| `Enhancement` | `Improvement` | `type:enhancement` + `category:improvement` | `improvement/{name}` | Minor |
+| `Enhancement` | `Refactor` | `type:enhancement` + `category:refactor` | `refactor/{name}` | Minor |
+
+How to pick:
+- **Bug** ... the script doesn't do what it was designed to do. Null check missing, wrong path, broken regex, off-by-one.
+- **Refactor** ... a redesign of how something is shaped. Spans both parent types ... `Problem/Refactor` when the original design was wrong (broken-shape redo, patch bump); `Enhancement/Refactor` when the original design works but is clunky (working-but-clunky redo, minor bump). Same branch prefix and same `category:refactor` label either way; the parent type column disambiguates motivation and semver.
+- **Improvement** ... an existing capability done better. Hardening, polish, clearer error output, integrity checks added to existing downloads.
+- **Feature** ... net-new capability. A new script, new delivery mechanism, new integration target.
+
+**`BREAKING:` PR title prefix** forces a major version bump regardless of category. (Future-state: applies once this repo carries a semver version.)
+
+**Name branches after the change, not the fix.** Good: `bug/iso-dismount-fails-on-server-2022`, `feature/jsdelivr-script-delivery`. Bad: `bug/my-fix`, `feature/wip`.
+
+**`dependabot/*` branches** ... categorize by the upstream change. CVE or upstream defect → `bug`. Major-version bump that takes new capability → `improvement` or `feature`.
+
+**Legacy prefixes:** `enhancement/` and `problem/` are deprecated by this taxonomy. Existing branches with these prefixes are accepted as-is and can merge under their original names; new work uses the four-prefix model above (`bug/`, `refactor/`, `improvement/`, `feature/`).
+
+### GitHub Labels
+
+Two-tier label set, one of each per PR:
+
+**Type labels:** `type:problem`, `type:enhancement`
+
+**Category labels:** `category:bug`, `category:refactor`, `category:improvement`, `category:feature`
+
+The legacy single-tier labels (`bug`, `enhancement`, `feature`) remain on the repo for issues opened under the old convention. New issues and PRs use the two-tier labels.
+
+### Workflow for All Changes
+
+1. **Create a typed branch off `main`**
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b feature/descriptive-name
+   # or bug/, refactor/, improvement/ per the taxonomy above
+   ```
+
+   Examples:
+   - `feature/jsdelivr-script-delivery`
+   - `improvement/vendor-download-integrity`
+   - `bug/iso-dismount-error`
+   - `refactor/rmm-input-handler-shared-helper`
+
+2. **Make changes on the branch**
+   - Make all code modifications on the typed branch
+   - Commit changes with descriptive messages
+   - Test thoroughly in both interactive and RMM modes
+
+3. **Push branch**
+   ```bash
+   git push -u origin feature/descriptive-name
+   ```
+
+4. **Create pull request**
+   - Open PR from your branch to `main`
+   - Apply the two labels from the taxonomy table (one `type:*` + one `category:*`)
+   - Include description of changes, testing performed, and RMM compatibility
+   - Wait for review and approval before merging
+
+5. **Merge to `main`**
+   - Only merge after testing and approval
+   - Delete the branch after successful merge
+
+### If Changes Are Accidentally Committed to Main
+
+```bash
+# Revert the commit from main
+git revert <commit-hash> --no-edit
+git push
+
+# Create the typed branch and restore the changes
+git checkout -b feature/descriptive-name
+git cherry-pick <commit-hash>
+git push -u origin feature/descriptive-name
+```
+
+### Exception: Documentation Updates
+
+Minor documentation updates to `CLAUDE.md` or `README.md` may be committed directly to `main` if they do not affect script functionality.

--- a/bdr-veeam/README.md
+++ b/bdr-veeam/README.md
@@ -9,22 +9,34 @@ These scripts form the automated BDR provisioning and monitoring pipeline. They 
 ### veeam-configure-backblaze-repo.ps1
 Creates a Backblaze B2 bucket and registers it as a Veeam S3-compatible repository.
 
+**Storage isolation is per-LOCATION, per-DEVICE:**
+
+```
+bucket:  veeam-{location-ouid-flat}     (one bucket per location)
+folder:  {device-ouid-dashed}/          (one repository root per BDR; Veeam owns everything below)
+```
+
+Locations get bought and sold, so the bucket tracks the location OUID (looked up at runtime from NinjaOne), not the org. The per-device folder is the BDR's device OUID, so a single location bucket can hold more than one BDR. The device OUID is recomputable from a stable source (minted once, persisted on the device), so re-runs and rebuilds resolve to the SAME folder and reclaim existing data. See [Cloud Backup Architecture Standards](https://kb.dtctoday.com/books/dtcs-pillars-of-technology/page/cloud-backup-architecture-standards) and [OUID Standard](https://kb.dtctoday.com/books/dtcs-pillars-of-technology/page/operational-uuid-ouid-standard).
+
+> **Prerequisite:** the device must already have a Device GUID. Run `rmm-ninja/ninja-ensure-device-guid.ps1` first (mints + persists the device OUID). This script fails fast if no Device GUID is found.
+
 **What it does:**
-1. Reads org UUID from NinjaRMM org-level field
-2. Creates a B2 bucket: `{org_uuid_nodashes}-{time_short_id}-veeam`
-3. Enables Object Lock (for immutability) and SSE-B2 encryption
+1. Reads location OUID from the NinjaRMM location field; computes bucket `veeam-{location-ouid-flat}`
+2. Resolves this device's OUID (registry `HKLM\SOFTWARE\DTC\DeviceGuid`, then NinjaOne field)
+3. Creates the B2 bucket; enables Object Lock (for immutability) and SSE-B2 encryption
 4. Sets lifecycle rule to purge hidden file versions after immutability + 1 day
 5. Creates a scoped B2 application key restricted to that bucket only
 6. Saves bucket name + scoped key to NinjaRMM device fields (before Veeam step)
-7. Registers the Veeam S3 repository with immutability enabled
+7. Registers the Veeam S3 repository with immutability enabled, rooted at the `{device-ouid}/` folder
 
-**Idempotency:** If bucket name + keys already exist in NinjaRMM, skips B2 creation and only creates the Veeam repo. Safe to re-run after failures.
+**Idempotency:** Bucket name and folder are both deterministic (location OUID, device OUID), so re-runs target the same paths. If bucket name + keys already exist in NinjaRMM, skips B2 creation and only creates the Veeam repo. Safe to re-run after failures.
 
 **NinjaRMM Fields:**
 
 | Variable | Level | Type | Purpose |
 |----------|-------|------|---------|
-| `CUSTOM_FIELD_ORG_UUID` | Org | Text | Organization UUID (read via Ninja-Property-Get) |
+| `CUSTOM_FIELD_LOCATION_UUID` | Location | Text | Location OUID (read via Ninja-Property-Get) |
+| `CUSTOM_FIELD_DEVICE_GUID` | Device | Text | Device OUID (fallback if registry empty; see ninja-ensure-device-guid.ps1) |
 | `B2_ADMIN_KEY_ID` | Org | Text | Master B2 key ID (never stored on device) |
 | `B2_ADMIN_APP_KEY` | Org | Secure | Master B2 app key |
 | `B2_ENDPOINT` | Org | Text | e.g. `https://s3.us-west-002.backblazeb2.com` |
@@ -65,6 +77,8 @@ Comprehensive inventory and health check. Populates multiple NinjaRMM fields.
 
 **What it detects:**
 - S3 bucket name and storage size (via Veeam backup copy job + child backup storages)
+- **Active vs inactive S3 repositories.** Active = a backup copy job currently targets the repo (live pipeline). Inactive = a registered S3 repo with no copy job pointing at it (e.g. a pre-move bucket left behind, still billable). Rendered as two separate tables in the inventory field, each with a Last Backup column.
+- **Total used space across all S3 repos** (active + inactive) — the full B2 footprint, so leftover buckets show up in the cost picture.
 - Orphaned/stale backups across all repos (configurable threshold, default 30 days)
 - Failed backup jobs (checks most recent session per job, clears when job succeeds)
 - Missing S3 copy job (no S3 repo, no copy job, or missing source jobs)
@@ -75,7 +89,8 @@ Comprehensive inventory and health check. Populates multiple NinjaRMM fields.
 |----------|------|---------|
 | `CUSTOM_FIELD_S3_BUCKET_NAME` | Text | Last used S3 bucket name |
 | `CUSTOM_FIELD_S3_BUCKET_SIZE` | Text | Last used S3 bucket size |
-| `CUSTOM_FIELD_S3_INVENTORY` | WYSIWYG | HTML table of all S3 repos |
+| `CUSTOM_FIELD_S3_TOTAL_SIZE` | Text | Total used space across ALL S3 repos (active + inactive) |
+| `CUSTOM_FIELD_S3_INVENTORY` | WYSIWYG | HTML tables: active + inactive S3 repos, with total |
 | `CUSTOM_FIELD_ORPHANS_FOUND` | Checkbox | 1 if orphaned backups exist |
 | `CUSTOM_FIELD_ORPHANED_BACKUPS` | WYSIWYG | HTML table of orphaned backups |
 | `CUSTOM_FIELD_FAILED_BACKUP` | Checkbox | 1 if any job's last run failed |

--- a/bdr-veeam/veeam-configure-backblaze-repo.ps1
+++ b/bdr-veeam/veeam-configure-backblaze-repo.ps1
@@ -2,15 +2,27 @@
 ## read/write access to only that bucket, registers the Veeam S3 repository
 ## using the scoped key, and stores credentials in NinjaRMM device fields.
 ##
-## Bucket naming: {ORG_UUID_no_dashes}-{time_based_short_id}-veeam
+## Bucket naming: veeam-{LOCATION_OUID_no_dashes}
+## Folder (object prefix) inside the bucket: {device_ouid_dashed}/
 ## Veeam repository name = bucket name
+##
+## Isolation is per-LOCATION (not per-org): locations get bought and sold, so the
+## storage boundary tracks the location OUID, read at runtime from NinjaOne. The
+## per-DEVICE folder (the BDR's device OUID) is the repository root for this BDR.
+## A single location bucket can hold more than one BDR while keeping each one's
+## data in its own prefix. The device OUID is used (not Veeam's internal instance
+## GUID, not a timestamp) because it is recomputable from a stable source: it is
+## minted once and persisted on the device (registry + NinjaOne), so re-runs and
+## rebuilds resolve to the SAME folder and reclaim existing data. Mint it first
+## with rmm-ninja\ninja-ensure-device-guid.ps1.
 ##
 ## ADMIN CREDENTIALS (org-level in NinjaRMM, used to create bucket + scoped key):
 ## $env:B2_ADMIN_KEY_ID               - Master/admin B2 application key ID
 ## $env:B2_ADMIN_APP_KEY              - Master/admin B2 application key
 ##
 ## CONFIGURATION:
-## $env:CUSTOM_FIELD_ORG_UUID          - NinjaOne text field containing the organization UUID (REQUIRED)
+## $env:CUSTOM_FIELD_LOCATION_UUID     - NinjaOne text field containing the location OUID (REQUIRED)
+## $env:CUSTOM_FIELD_DEVICE_GUID       - NinjaOne device text field containing the device OUID (fallback if registry is empty)
 ## $env:B2_ENDPOINT                   - S3 endpoint (e.g. https://s3.us-west-002.backblazeb2.com)
 ## $env:B2_REGION                     - S3 region ID (e.g. us-west-002)
 ## $env:IMMUTABILITY_DAYS             - Object lock immutability period in days (default: 14)
@@ -78,19 +90,39 @@ if ($PSVersionTable.PSVersion.Major -ge 7) {
 # HELPER FUNCTIONS
 # ============================================================
 
-function New-TimeBasedShortId {
-    # Generates a short time-based ID from a UUIDv7-style timestamp.
-    # Uses milliseconds since Unix epoch encoded in base36 for compactness.
-    # 8 chars of base36 = ~2.8 trillion values, unique to the millisecond.
-    $MS = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
-    $CHARS = "0123456789abcdefghijklmnopqrstuvwxyz"
-    $RESULT = ""
-    while ($MS -gt 0) {
-        $RESULT = $CHARS[$MS % 36] + $RESULT
-        $MS = [Math]::Floor($MS / 36)
+$GUID_REGEX = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+
+function Get-DeviceOuid {
+    # Returns this device's OUID (the "Device GUID"), used as the repository-root
+    # folder name inside the location bucket. Per the DTC OUID Standard, the
+    # device OUID is minted once and persisted on the device, so it is
+    # recomputable from a stable source: re-runs and rebuilds resolve to the SAME
+    # folder and reclaim existing backup data. Mint it with
+    # rmm-ninja\ninja-ensure-device-guid.ps1 before running this script.
+    #
+    # Sources tried in order: (1) on-device registry (authoritative mirror, no
+    # network needed), (2) NinjaOne device custom field. Returns $null if neither
+    # holds a valid GUID -- caller must handle that.
+
+    # 1. On-device registry: HKLM\SOFTWARE\DTC\DeviceGuid
+    try {
+        $REG = Get-ItemProperty -Path 'HKLM:\SOFTWARE\DTC' -Name 'DeviceGuid' -ErrorAction Stop
+        if ($REG.DeviceGuid -and "$($REG.DeviceGuid)" -match $GUID_REGEX) {
+            return "$($REG.DeviceGuid)".ToLower()
+        }
+    } catch { }
+
+    # 2. NinjaOne device custom field
+    if ($env:CUSTOM_FIELD_DEVICE_GUID) {
+        try {
+            $NINJA_VAL = Ninja-Property-Get $env:CUSTOM_FIELD_DEVICE_GUID 2>$null
+            if ($NINJA_VAL -and "$NINJA_VAL" -match $GUID_REGEX) {
+                return "$NINJA_VAL".ToLower()
+            }
+        } catch { }
     }
-    # Pad to 8 chars or truncate
-    return $RESULT.PadLeft(8, '0').Substring(0, 8)
+
+    return $null
 }
 
 function Invoke-B2Api {
@@ -148,7 +180,7 @@ if ($env:RMM -ne "1") {
         $env:DESCRIPTION = Read-Host "Ticket # or initials for audit trail"
         if ($env:DESCRIPTION) { $VALID_INPUT = 1 } else { Write-Host "Required." }
     }
-    if (-not $env:CUSTOM_FIELD_ORG_UUID) { $env:CUSTOM_FIELD_ORG_UUID = Read-Host "Organization UUID (REQUIRED)" }
+    if (-not $env:CUSTOM_FIELD_LOCATION_UUID) { $env:CUSTOM_FIELD_LOCATION_UUID = Read-Host "Location OUID NinjaOne field name (REQUIRED)" }
     if (-not $env:B2_ADMIN_KEY_ID) { $env:B2_ADMIN_KEY_ID = Read-Host "B2 admin key ID (master key)" }
     if (-not $env:B2_ADMIN_APP_KEY) { $env:B2_ADMIN_APP_KEY = Read-Host "B2 admin app key (master key)" }
     if (-not $env:B2_ENDPOINT) { $env:B2_ENDPOINT = Read-Host "B2 S3 endpoint (e.g. https://s3.us-west-002.backblazeb2.com)" }
@@ -197,45 +229,43 @@ Write-Host "=== Veeam S3 Repository Creation ==="
 Write-Host "Description: $env:DESCRIPTION"
 Write-Host ""
 
-# Org UUID: CUSTOM_FIELD_ORG_UUID contains the NinjaOne field NAME (e.g. "dtcOrgGuid").
-# We pass that to Ninja-Property-Get to read the actual UUID value.
-$ORG_UUID = $null
-if ($env:CUSTOM_FIELD_ORG_UUID) {
+# Location OUID: CUSTOM_FIELD_LOCATION_UUID contains the NinjaOne field NAME
+# (e.g. "dtcLocationGuid"). We pass that to Ninja-Property-Get to read the value.
+# Isolation is per-location: locations get bought/sold, so the bucket tracks the
+# location OUID rather than the org.
+$LOCATION_UUID = $null
+if ($env:CUSTOM_FIELD_LOCATION_UUID) {
     try {
-        $ORG_UUID = Ninja-Property-Get $env:CUSTOM_FIELD_ORG_UUID 2>$null
+        $LOCATION_UUID = Ninja-Property-Get $env:CUSTOM_FIELD_LOCATION_UUID 2>$null
     } catch { }
 }
-if (-not $ORG_UUID) {
-    Write-Error "CUSTOM_FIELD_ORG_UUID is empty. Set the org UUID field in NinjaRMM."
+if (-not $LOCATION_UUID) {
+    Write-Error "CUSTOM_FIELD_LOCATION_UUID is empty. Set the location OUID field in NinjaRMM."
     Stop-Transcript
     exit 1
 }
 # Validate it's actually a UUID, not a field name or garbage
-if ($ORG_UUID -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
-    Write-Error "CUSTOM_FIELD_ORG_UUID value '$ORG_UUID' is not a valid UUID. Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+if ($LOCATION_UUID -notmatch $GUID_REGEX) {
+    Write-Error "CUSTOM_FIELD_LOCATION_UUID value '$LOCATION_UUID' is not a valid UUID. Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     Stop-Transcript
     exit 1
 }
-Write-Host "Org UUID: $ORG_UUID"
-$ORG_PREFIX = $ORG_UUID.Replace("-", "").ToLower()
+Write-Host "Location OUID: $LOCATION_UUID"
+$LOCATION_PREFIX = $LOCATION_UUID.Replace("-", "").ToLower()
 
-# Generate time-based short ID for this bucket
-$BUCKET_SHORT_ID = New-TimeBasedShortId
-$BUCKET_NAME = "$ORG_PREFIX-$BUCKET_SHORT_ID-veeam"
+# Bucket name = veeam-{location-ouid-flat}. Deterministic: re-runs compute the
+# same name. "veeam-" (6) + 32 hex = 38 chars, within B2's 50-char limit.
+$BUCKET_NAME = "veeam-$LOCATION_PREFIX"
 
 # S3 bucket name validation: lowercase alphanumeric + hyphens, 3-50 chars
 $BUCKET_NAME = $BUCKET_NAME -replace '[^a-z0-9\-]', ''
 if ($BUCKET_NAME.Length -gt 50) {
-    # Truncate org prefix to fit
-    $MAX_ORG = 50 - 1 - 8 - 1 - 5  # dash + shortid + dash + "veeam"
-    $ORG_PREFIX = $ORG_PREFIX.Substring(0, $MAX_ORG)
-    $BUCKET_NAME = "$ORG_PREFIX-$BUCKET_SHORT_ID-veeam"
+    $BUCKET_NAME = $BUCKET_NAME.Substring(0, 50)
 }
 
 Write-Host "Bucket name:       $BUCKET_NAME"
-Write-Host "Org UUID:          $ORG_UUID"
-Write-Host "Org prefix:        $ORG_PREFIX"
-Write-Host "Bucket short ID:   $BUCKET_SHORT_ID"
+Write-Host "Location OUID:     $LOCATION_UUID"
+Write-Host "Location prefix:   $LOCATION_PREFIX"
 Write-Host "Endpoint:          $env:B2_ENDPOINT"
 Write-Host "Region:            $env:B2_REGION"
 Write-Host "Immutability:      $IMMUTABILITY_DAYS days"
@@ -261,6 +291,20 @@ if ($VBR_MODULES = Get-Module -ListAvailable -Name Veeam.Backup.PowerShell) {
     Stop-Transcript
     throw "Veeam.Backup.PowerShell module not found."
 }
+
+# ============================================================
+# RESOLVE THIS DEVICE'S OUID (repository-root folder name)
+# ============================================================
+
+Write-Host ""
+Write-Host "Resolving device OUID..."
+$DEVICE_GUID = Get-DeviceOuid
+if (-not $DEVICE_GUID) {
+    Write-Error "Could not resolve a device OUID. Run rmm-ninja\ninja-ensure-device-guid.ps1 on this device first (mints + persists the Device GUID), then re-run."
+    Stop-Transcript
+    exit 1
+}
+Write-Host "  [OK] Device OUID: $DEVICE_GUID"
 
 # ============================================================
 # CHECK IF BUCKET + KEYS ALREADY EXIST (idempotency)
@@ -309,10 +353,6 @@ if ($EXISTING_BUCKET -and $EXISTING_KEY_ID -and $EXISTING_APP_KEY) {
     $BUCKET_NAME = $EXISTING_BUCKET
     $SCOPED_KEY_ID = $EXISTING_KEY_ID
     $SCOPED_APP_KEY = $EXISTING_APP_KEY
-    # Extract short ID from existing bucket name for folder creation
-    if ($BUCKET_NAME -match '-([a-z0-9]{8})-veeam$') {
-        $BUCKET_SHORT_ID = $Matches[1]
-    }
     $SKIP_B2_CREATION = $true
 }
 
@@ -539,9 +579,12 @@ try {
     $VEEAM_BUCKET = Get-VBRAmazonS3Bucket -Connection $VEEAM_CONNECTION -Name $BUCKET_NAME
     Write-Host "  [OK] Bucket found in Veeam."
 
-    # Create a folder inside the bucket (use the short ID as folder name)
-    $VEEAM_FOLDER = New-VBRAmazonS3Folder -Name $BUCKET_SHORT_ID -Connection $VEEAM_CONNECTION -Bucket $VEEAM_BUCKET
-    Write-Host "  [OK] Folder created: $BUCKET_SHORT_ID"
+    # Create a folder inside the bucket, named for this device's OUID. This is
+    # the repository root for THIS BDR; Veeam owns everything below it. Another
+    # BDR at the same location gets its own folder. The device OUID is stable, so
+    # a rebuild of this BDR resolves to the same folder and reclaims its data.
+    $VEEAM_FOLDER = New-VBRAmazonS3Folder -Name $DEVICE_GUID -Connection $VEEAM_CONNECTION -Bucket $VEEAM_BUCKET
+    Write-Host "  [OK] Folder created: $DEVICE_GUID"
 
     # Create the repository (name = bucket name)
     # -Confirm:$false suppresses ShouldProcess prompts
@@ -576,7 +619,7 @@ Write-Host ""
 Write-Host "=== Complete ==="
 Write-Host "  Bucket:       $BUCKET_NAME"
 Write-Host "  Repository:   $BUCKET_NAME"
-Write-Host "  Folder:       $BUCKET_SHORT_ID"
+Write-Host "  Folder:       $DEVICE_GUID"
 Write-Host "  Scoped key:   $($SCOPED_KEY_ID_OUT.Substring(0, [Math]::Min(8, $SCOPED_KEY_ID_OUT.Length)))..."
 Write-Host "  Immutability: $IMMUTABILITY_DAYS days"
 Write-Host ""

--- a/bdr-veeam/veeam-inventory.ps1
+++ b/bdr-veeam/veeam-inventory.ps1
@@ -1,7 +1,8 @@
 ## PLEASE SET THE FOLLOWING ENVIRONMENT VARIABLES IN YOUR RMM BEFORE RUNNING
 ## $env:CUSTOM_FIELD_S3_BUCKET_NAME    - Text field: last used S3 bucket name
 ## $env:CUSTOM_FIELD_S3_BUCKET_SIZE    - Text field: last used S3 bucket size (human readable)
-## $env:CUSTOM_FIELD_S3_INVENTORY      - WYSIWYG field: HTML table of all S3 repos
+## $env:CUSTOM_FIELD_S3_TOTAL_SIZE     - Text field: total used space across ALL S3 repos (active + inactive)
+## $env:CUSTOM_FIELD_S3_INVENTORY      - WYSIWYG field: HTML tables of active + inactive S3 repos
 ## $env:CUSTOM_FIELD_ORPHANS_FOUND     - Integer field: 1 if orphaned backups found, 0 if not
 ## $env:CUSTOM_FIELD_ORPHANED_BACKUPS  - WYSIWYG field: HTML table of orphaned/stale backup data (all repos)
 ## $env:CUSTOM_FIELD_FAILED_BACKUP     - Checkbox field: checked if any backup job's last run failed
@@ -81,8 +82,14 @@ function Build-HtmlTable {
         [string[]]$Headers,
         [System.Collections.Generic.List[string[]]]$Rows,
         [string]$ScanTimestamp,
-        [string]$EmptyMessage = "No data found."
+        [string]$EmptyMessage = "No data found.",
+        [string]$Title = ""
     )
+
+    $TITLE_HTML = ""
+    if ($Title) {
+        $TITLE_HTML = "    <p style=`"margin:0 0 6px;font-size:14px;font-weight:600;color:#111827;`">$(ConvertTo-SafeHtml $Title)</p>`n"
+    }
 
     $HEADER_CELLS = ""
     foreach ($H in $Headers) {
@@ -115,8 +122,8 @@ $CELLS        </tr>
     }
 
     return @"
-<div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#111827;">
-    <table style="width:100%;border-collapse:collapse;border:1px solid #d1d5db;border-radius:4px;overflow:hidden;">
+<div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#111827;margin-bottom:14px;">
+$TITLE_HTML    <table style="width:100%;border-collapse:collapse;border:1px solid #d1d5db;border-radius:4px;overflow:hidden;">
         <thead>
             <tr style="background-color:#f3f4f6;">
 $HEADER_CELLS            </tr>
@@ -169,6 +176,7 @@ if ($env:RMM -ne "1") {
 
     $env:CUSTOM_FIELD_S3_BUCKET_NAME = Read-Host "NinjaOne text field for S3 bucket name (blank to skip)"
     $env:CUSTOM_FIELD_S3_BUCKET_SIZE = Read-Host "NinjaOne text field for S3 bucket size (blank to skip)"
+    $env:CUSTOM_FIELD_S3_TOTAL_SIZE = Read-Host "NinjaOne text field for total S3 size across all repos (blank to skip)"
     $env:CUSTOM_FIELD_S3_INVENTORY = Read-Host "NinjaOne WYSIWYG field for S3 inventory table (blank to skip)"
     $env:CUSTOM_FIELD_ORPHANS_FOUND = Read-Host "NinjaOne integer field for orphans found flag (blank to skip)"
     $env:CUSTOM_FIELD_ORPHANED_BACKUPS = Read-Host "NinjaOne WYSIWYG field for orphaned backups table (blank to skip)"
@@ -402,7 +410,15 @@ foreach ($BACKUP in $ALL_BACKUPS) {
 Write-Host ""
 Write-Host "Processing repositories..."
 
+# Union of all repo rows (used for the single-repo fallback + console dump),
+# plus the active/inactive split that drives the two inventory tables.
+# Row schema: @(BucketName, RepoName, Type, UsedSpace, LastBackup)
 $REPO_ROWS = [System.Collections.Generic.List[string[]]]::new()
+$ACTIVE_REPO_ROWS = [System.Collections.Generic.List[string[]]]::new()
+$INACTIVE_REPO_ROWS = [System.Collections.Generic.List[string[]]]::new()
+
+# Total used space across ALL S3 repos (active + inactive) -> total B2 footprint.
+$TOTAL_S3_BYTES = [long]0
 
 $LAST_USED_BUCKET = "N/A"
 $LAST_USED_SIZE = "N/A"
@@ -412,6 +428,11 @@ $LAST_USED_TIME = [datetime]::MinValue
 foreach ($REPO in $OBJECT_STORAGE_REPOS) {
     $REPO_ID = $REPO.Id.ToString()
     Write-Host "  Processing: $($REPO.Name)"
+
+    # A repo is ACTIVE if a backup copy job currently targets it (it's wired into
+    # the live backup pipeline). Otherwise it's INACTIVE -- a registered repo no
+    # longer receiving data (e.g. a pre-move bucket left behind), still billable.
+    $IS_ACTIVE = $COPY_JOB_REPOS.ContainsKey($REPO_ID)
 
     # --- BUCKET NAME ---
     $BUCKET_NAME = "N/A"
@@ -451,9 +472,7 @@ foreach ($REPO in $OBJECT_STORAGE_REPOS) {
     try { if ($REPO.Type) { $REPO_TYPE = $REPO.Type.ToString() } } catch {}
     try { if ($REPO_TYPE -eq "N/A" -and $REPO.TypeDisplay) { $REPO_TYPE = $REPO.TypeDisplay } } catch {}
 
-    $REPO_ROWS.Add(@($BUCKET_NAME, $REPO.Name, $REPO_TYPE, $USED_SPACE_DISPLAY))
-
-    # --- LAST USED tracking ---
+    # --- LAST BACKUP (most recent restore point in this repo) ---
     $REPO_LATEST_TIME = [datetime]::MinValue
     if ($S3_CHILDREN_BY_REPO_ID.ContainsKey($REPO_ID)) {
         foreach ($CHILD in $S3_CHILDREN_BY_REPO_ID[$REPO_ID]) {
@@ -462,6 +481,15 @@ foreach ($REPO in $OBJECT_STORAGE_REPOS) {
             }
         }
     }
+    $LAST_BACKUP_STR = if ($REPO_LATEST_TIME -gt [datetime]::MinValue) { $REPO_LATEST_TIME.ToString("yyyy-MM-dd") } else { "N/A" }
+
+    # --- ROW + ACTIVE/INACTIVE SPLIT + RUNNING TOTAL ---
+    $ROW = @($BUCKET_NAME, $REPO.Name, $REPO_TYPE, $USED_SPACE_DISPLAY, $LAST_BACKUP_STR)
+    $REPO_ROWS.Add($ROW)
+    if ($IS_ACTIVE) { $ACTIVE_REPO_ROWS.Add($ROW) } else { $INACTIVE_REPO_ROWS.Add($ROW) }
+    $TOTAL_S3_BYTES += $USED_SPACE_BYTES
+
+    # --- LAST USED tracking (drives the single-bucket scalar fields) ---
     if ($REPO_LATEST_TIME -gt $LAST_USED_TIME) {
         $LAST_USED_TIME = $REPO_LATEST_TIME
         $LAST_USED_BUCKET = $BUCKET_NAME
@@ -469,6 +497,8 @@ foreach ($REPO in $OBJECT_STORAGE_REPOS) {
         $LAST_USED_SIZE_BYTES = $USED_SPACE_BYTES
     }
 }
+
+$TOTAL_S3_SIZE_DISPLAY = Format-SizeBytes -Bytes $TOTAL_S3_BYTES
 
 # --- ORPHAN ROWS (all repos) ---
 $ORPHAN_ROWS = [System.Collections.Generic.List[string[]]]::new()
@@ -598,17 +628,23 @@ Write-Host ""
 Write-Host "=== Results ==="
 Write-Host "  Last used S3 bucket: $LAST_USED_BUCKET"
 Write-Host "  Last used S3 size:   $LAST_USED_SIZE"
-Write-Host "  S3 repos found:      $($REPO_ROWS.Count)"
+Write-Host "  S3 repos found:      $($REPO_ROWS.Count) (active: $($ACTIVE_REPO_ROWS.Count), inactive: $($INACTIVE_REPO_ROWS.Count))"
+Write-Host "  Total S3 size (all): $TOTAL_S3_SIZE_DISPLAY"
 Write-Host "  Orphaned backups:    $ORPHAN_COUNT"
 Write-Host "  Failed backups:      $FAILED_COUNT"
 Write-Host "  S3 copy job missing: $S3_COPY_MISSING $(if ($S3_COPY_MISSING_REASON) { "($S3_COPY_MISSING_REASON)" })"
 Write-Host ""
 
 if ($REPO_ROWS.Count -gt 0) {
-    Write-Host "=== Inventory ==="
-    foreach ($ROW in $REPO_ROWS) {
-        Write-Host "  Bucket: $($ROW[0]) | Repo: $($ROW[1]) | Type: $($ROW[2]) | Size: $($ROW[3])"
+    Write-Host "=== Active S3 Repositories ($($ACTIVE_REPO_ROWS.Count)) ==="
+    foreach ($ROW in $ACTIVE_REPO_ROWS) {
+        Write-Host "  Bucket: $($ROW[0]) | Repo: $($ROW[1]) | Type: $($ROW[2]) | Size: $($ROW[3]) | Last backup: $($ROW[4])"
     }
+    Write-Host "=== Inactive S3 Repositories ($($INACTIVE_REPO_ROWS.Count)) ==="
+    foreach ($ROW in $INACTIVE_REPO_ROWS) {
+        Write-Host "  Bucket: $($ROW[0]) | Repo: $($ROW[1]) | Type: $($ROW[2]) | Size: $($ROW[3]) | Last backup: $($ROW[4])"
+    }
+    Write-Host "  Total across all S3 repos: $TOTAL_S3_SIZE_DISPLAY"
     Write-Host ""
 }
 
@@ -631,11 +667,25 @@ if ($FAILED_COUNT -gt 0) {
 # ------------------------------------------------------------
 # Build HTML tables
 # ------------------------------------------------------------
-$HTML_INVENTORY = Build-HtmlTable `
-    -Headers @("Bucket Name", "Repository Name", "Type", "Used Space") `
-    -Rows $REPO_ROWS `
+$INVENTORY_HEADERS = @("Bucket Name", "Repository Name", "Type", "Used Space", "Last Backup")
+
+$HTML_ACTIVE = Build-HtmlTable `
+    -Title "Active S3 Repositories ($($ACTIVE_REPO_ROWS.Count))" `
+    -Headers $INVENTORY_HEADERS `
+    -Rows $ACTIVE_REPO_ROWS `
     -ScanTimestamp $SCAN_TIMESTAMP `
-    -EmptyMessage "No S3-compatible object storage repositories found."
+    -EmptyMessage "No active S3 repositories (no backup copy job targets an S3 repo)."
+
+$HTML_INACTIVE = Build-HtmlTable `
+    -Title "Inactive S3 Repositories ($($INACTIVE_REPO_ROWS.Count))" `
+    -Headers $INVENTORY_HEADERS `
+    -Rows $INACTIVE_REPO_ROWS `
+    -ScanTimestamp $SCAN_TIMESTAMP `
+    -EmptyMessage "No inactive S3 repositories."
+
+$HTML_TOTAL = "<p style=`"font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:600;color:#111827;margin:0 0 12px;`">Total used space across all S3 repositories: $(ConvertTo-SafeHtml $TOTAL_S3_SIZE_DISPLAY)</p>"
+
+$HTML_INVENTORY = $HTML_TOTAL + $HTML_ACTIVE + $HTML_INACTIVE
 
 $HTML_ORPHANS = Build-HtmlTable `
     -Headers @("Machine", "Size", "Last Backup", "Reason", "Repository") `
@@ -656,6 +706,7 @@ Write-Host "Writing to NinjaOne custom fields..."
 
 Set-NinjaField $env:CUSTOM_FIELD_S3_BUCKET_NAME $LAST_USED_BUCKET
 Set-NinjaField $env:CUSTOM_FIELD_S3_BUCKET_SIZE $LAST_USED_SIZE
+Set-NinjaField $env:CUSTOM_FIELD_S3_TOTAL_SIZE $TOTAL_S3_SIZE_DISPLAY
 Set-NinjaField $env:CUSTOM_FIELD_S3_INVENTORY $HTML_INVENTORY
 Set-NinjaField $env:CUSTOM_FIELD_ORPHANS_FOUND "$([int]($ORPHAN_COUNT -gt 0))"
 Set-NinjaField $env:CUSTOM_FIELD_ORPHANED_BACKUPS $HTML_ORPHANS

--- a/integrations/ninja-halo-guid-sync.ps1
+++ b/integrations/ninja-halo-guid-sync.ps1
@@ -1,0 +1,177 @@
+<#
+.SYNOPSIS
+    Syncs DTC Org GUID from NinjaRMM organizations to Halo PSA client custom field.
+
+.DESCRIPTION
+    Reads the dtcOrgGuid custom field from each NinjaRMM organization and writes
+    it to the CFDtcClientGuid field in Halo PSA for all exactly-matched clients.
+
+    Runs unattended via NinjaOne Scheduled Task (Sundays 2:00 AM EDT).
+    Matching is exact by client name. Name mismatches are logged and skipped.
+
+.PARAMETER haloclientsecret
+    Halo PSA API client secret. Injected by NinjaOne Script Variable: haloclientsecret.
+
+.PARAMETER ninjaclientsecret
+    NinjaRMM API client secret. Injected by NinjaOne Script Variable: ninjaclientsecret.
+
+.NOTES
+    Author:      Tyler Dantzler
+    Repo:        DTC-Inc/msp-script-library/integrations/ninja-halo-guid-sync.ps1
+    BookStack:   Page 1908
+    Schedule:    Weekly, Sundays 2:00 AM EDT (NinjaOne Scheduled Task)
+
+    ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU ARE RUNNING FROM A RMM
+    # $env:RMM             -- set to "1" by NinjaOne at runtime; controls RMM vs interactive mode
+    # $env:Description     -- human-readable audit trail label for this run
+    # $env:haloclientsecret  -- Halo PSA API client secret (NinjaOne Script Variable)
+    # $env:ninjaclientsecret -- NinjaRMM API client secret (NinjaOne Script Variable)
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+# --- AUDIT TRAIL & LOGGING ---
+$ScriptLogName = 'ninja-halo-guid-sync'
+$Description   = if ($env:Description) { $env:Description } else { 'NinjaRMM to Halo PSA GUID sync (manual run)' }
+$logPath       = "C:\ProgramData\DTC\Logs\$ScriptLogName-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+New-Item -ItemType Directory -Path (Split-Path $logPath) -Force | Out-Null
+Start-Transcript -Path $logPath -Append
+
+Write-Information "[$ScriptLogName] Starting — $Description" -InformationAction Continue
+
+try {
+
+    # --- CONFIGURATION ---
+    # Client IDs are not secrets — hardcoded here.
+    # Client secrets are injected via NinjaOne Script Variables (env vars at runtime).
+    $HaloClientId      = '25542a6d-2d0e-4093-bf82-e11edc64faf6'
+    $HaloClientSecret  = $env:haloclientsecret
+    $HaloBaseUrl       = 'https://psa.dtctoday.com'
+    $HaloScope         = 'read:customers edit:customers'
+
+    $NinjaClientId     = '0S1xEjce1FQp7Rbn_GJTrSWTp64'
+    $NinjaClientSecret = $env:ninjaclientsecret
+    $NinjaBaseUrl      = 'https://app.ninjarmm.com'
+
+    # --- VALIDATE SECRETS ---
+    $missing = @()
+    if ([string]::IsNullOrWhiteSpace($HaloClientSecret))  { $missing += 'haloclientsecret' }
+    if ([string]::IsNullOrWhiteSpace($NinjaClientSecret)) { $missing += 'ninjaclientsecret' }
+
+    if ($missing.Count -gt 0) {
+        throw "Missing NinjaOne Script Variables: $($missing -join ', '). Set default values in Library > Automation > Halo GUID Sync > Script Variables."
+    }
+
+    # --- AUTHENTICATE: HALO ---
+    Write-Information '  Authenticating with Halo PSA...' -InformationAction Continue
+    $haloTokenResp = Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/auth/token" `
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
+            client_id     = $HaloClientId
+            client_secret = $HaloClientSecret
+            scope         = $HaloScope
+        }
+    $haloToken   = $haloTokenResp.access_token
+    $haloHeaders = @{ Authorization = "Bearer $haloToken" }
+    Write-Information '  Halo auth OK' -InformationAction Continue
+
+    # --- AUTHENTICATE: NINJA ---
+    Write-Information '  Authenticating with NinjaRMM...' -InformationAction Continue
+    $ninjaTokenResp = Invoke-RestMethod -Method Post -Uri "$NinjaBaseUrl/ws/oauth/token" `
+        -ContentType 'application/x-www-form-urlencoded' -Body @{
+            grant_type    = 'client_credentials'
+            client_id     = $NinjaClientId
+            client_secret = $NinjaClientSecret
+            scope         = 'monitoring management'
+        }
+    $ninjaToken   = $ninjaTokenResp.access_token
+    $ninjaHeaders = @{ Authorization = "Bearer $ninjaToken" }
+    Write-Information '  Ninja auth OK' -InformationAction Continue
+
+    # --- PULL NINJA ORGS ---
+    $orgs    = Invoke-RestMethod -Method Get -Uri "$NinjaBaseUrl/v2/organizations" -Headers $ninjaHeaders
+    $results = @()
+
+    foreach ($org in $orgs) {
+        $orgName = $org.name
+        $orgId   = $org.id
+
+        # Read DTC Org GUID custom field
+        try {
+            $cf   = Invoke-RestMethod -Method Get `
+                -Uri "$NinjaBaseUrl/v2/organization/$orgId/custom-fields" -Headers $ninjaHeaders
+            $guid = $cf.dtcOrgGuid
+        } catch {
+            Write-Warning "Could not read custom fields for '$orgName' — skipping"
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($guid)) {
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No GUID'; GUID = '' }
+            continue
+        }
+
+        # Search Halo for matching client by exact name
+        try {
+            $haloSearch = Invoke-RestMethod -Method Get `
+                -Uri "$HaloBaseUrl/api/client?search=$([uri]::EscapeDataString($orgName))" `
+                -Headers $haloHeaders
+        } catch {
+            Write-Warning "Halo search failed for '$orgName' — skipping"
+            continue
+        }
+
+        $haloClient = $haloSearch.clients | Where-Object { $_.name -eq $orgName } | Select-Object -First 1
+
+        if (-not $haloClient) {
+            Write-Warning "No exact Halo match for '$orgName' — skipping"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'No Halo match'; GUID = $guid }
+            continue
+        }
+
+        # Build body — PowerShell 5 unwraps single-item @() on ConvertTo-Json so manually wrap in []
+        $clientUpdate = @{
+            id           = $haloClient.id
+            customfields = @(
+                @{ name = 'CFDtcClientGuid'; value = $guid }
+            )
+        }
+        $body = '[' + ($clientUpdate | ConvertTo-Json -Depth 5) + ']'
+
+        try {
+            Invoke-RestMethod -Method Post -Uri "$HaloBaseUrl/api/client" `
+                -Headers $haloHeaders -ContentType 'application/json' -Body $body | Out-Null
+            Write-Information "  [OK] $orgName" -InformationAction Continue
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Updated'; GUID = $guid }
+        } catch {
+            $errorDetail = $_.ErrorDetails.Message
+            Write-Warning "Failed to update '$orgName' — $($_.Exception.Message) | $errorDetail"
+            $results += [PSCustomObject]@{ NinjaOrg = $orgName; Status = 'Failed'; GUID = $guid }
+        }
+    }
+
+    # --- SUMMARY ---
+    Write-Information '' -InformationAction Continue
+    Write-Information '===== SYNC SUMMARY =====' -InformationAction Continue
+    $results | Format-Table -AutoSize
+
+    $failed = $results | Where-Object { $_.Status -eq 'Failed' }
+    if ($failed) {
+        Write-Warning "$($failed.Count) client(s) failed to update — see above"
+        exit 2
+    }
+
+    Write-Information "[$ScriptLogName] Completed successfully." -InformationAction Continue
+    exit 0
+
+} catch {
+    Write-Error "FAILED: $_"
+    Write-Error $_.ScriptStackTrace
+    exit 1
+} finally {
+    Stop-Transcript
+}

--- a/rmm-ninja/lockhart-remediation.ps1
+++ b/rmm-ninja/lockhart-remediation.ps1
@@ -1,0 +1,1296 @@
+<#
+.SYNOPSIS
+  NinjaOne Backup - Lockhart Remediation / Repair. Diagnoses and repairs failed
+  NinjaOne Backup jobs by examining the Lockhart service and its dependencies,
+  then restoring the device to a backup-ready state when safe to do so.
+
+.DESCRIPTION
+  Responds to NinjaOne condition "Backup Job Last success 25 hours ago"
+  (policy 58). Flow: HV0-skip -> CHECK -> DIAGNOSE -> REPAIR (gated) ->
+  CONFIRM -> STATE.
+
+  Excluded hosts: any hostname matching ^HV0 (Hyper-V hosts). Checked at
+  entry point before any file writes, transcript, or mutex creation.
+
+  RMM INTEGRATION (per repo CLAUDE.md):
+    - Execution context detected via $env:RMM ('1' = RMM mode).
+    - NinjaRMM passes script preset variables as ENVIRONMENT variables.
+      Every parameter below can be overridden by a same-named NinjaOne
+      script variable. In particular the NOC checkboxes:
+        ForceDisruptiveRepairs=1  and  ClearStateAndExit=1
+      are read from $env: (CLI switches also work for interactive use).
+    - $env:Description captured for audit trail.
+    - Transcript logging: $env:RMMScriptPath\logs\ in RMM mode (fallback
+      $env:WINDIR\logs\), $env:WINDIR\logs\ interactive. 10MB rotation.
+    - Template deviation (deliberate): no Read-Host prompts. This script
+      is condition-triggered automation and must never block on input;
+      a hung prompt would silence backup remediation fleet-wide.
+
+  Device-offline short-circuit (sole reason, no counter increment):
+    - Public internet unreachable
+    - System uptime < MinUptimeMinutes
+
+  Business hours gating (default 07:00-18:00 device-local):
+    During business hours, these repairs defer to off-hours:
+      - Dnscache service restart
+      - ARP cache clear
+      - VSS DLL re-registration (escalation)
+      - NinjaRMMAgent restart (escalation)
+    Override with -ForceDisruptiveRepairs or env ForceDisruptiveRepairs=1.
+
+  Anytime repairs:
+    - DNS cache flush
+    - Time resync
+    - Windows\Temp cleanup
+    - NinjaRMMAgent start (if stopped)
+    - VSS stack reset
+    - Force-kill stuck Lockhart
+    - Lockhart start/restart
+
+  Diagnosed but not repaired (forensic capture, NOC escalation):
+    - Cloud endpoints unreachable post-repair
+    - DNS / default gateway unreachable post-repair
+    - AV quarantine of lockhart.exe
+    - Lockhart binary missing
+    - agent.yaml missing or corrupt
+    - Disk space critically low post-cleanup
+
+  Counter: tracks remediation INTERVENTIONS (successful or not) within the
+  CounterResetHours window. Auto-reset after a 48h gap, or when a run finds
+  everything healthy with no repairs needed (AlreadyHealthy_CounterCleared).
+  No increment on DeviceOffline*, RemediationDeferred, or LiveJobSkipped.
+  Guardrail at MaxConsecutiveAttempts interventions - needing repeated
+  intervention, even successful, indicates a recurring root cause that
+  requires human investigation.
+
+  Auto-close: NinjaOne condition clears alert + Halo ticket when next
+  scheduled backup succeeds. Script does not touch alert or Halo flow.
+
+.PARAMETER SampleSeconds
+  Duration of process I/O + CPU sampling window for live backup detection.
+  Default 90. Lower = faster runs but more false-positive "stuck" classifications.
+
+.PARAMETER ActiveIoThresholdMB
+  Process I/O delta in MB over SampleSeconds that indicates an active backup.
+  Default 10.
+
+.PARAMETER ActiveCpuThresholdSec
+  Process CPU delta in seconds over SampleSeconds that indicates active work.
+  Default 5.0.
+
+.PARAMETER MaxConsecutiveAttempts
+  Number of consecutive remediation interventions (successful or failed)
+  within the CounterResetHours window before the script stops acting and
+  escalates to NOC. Repeated interventions - even when each one succeeds -
+  indicate a recurring underlying issue. Default 2.
+
+.PARAMETER CounterResetHours
+  Hours of no script execution before the intervention counter auto-resets.
+  Default 48 (the condition wouldn't re-fire if backups were working).
+
+.PARAMETER MinFreeSpacePercent
+  Minimum system drive free space percentage. Below this triggers temp cleanup
+  and is reported as a hard blocker if cleanup doesn't recover it. Default 10.
+
+.PARAMETER NetTestTimeoutMs
+  TCP connection test timeout per endpoint in milliseconds. Default 5000.
+
+.PARAMETER DnsTimeoutMs
+  DNS resolution test timeout per host in milliseconds. Default 4000.
+
+.PARAMETER TempCleanupMinAgeDays
+  Files in Windows\Temp older than this many days are eligible for cleanup
+  when free space is low. Default 7.
+
+.PARAMETER MaxRuntimeSeconds
+  Hard cap on total script runtime. Background job force-kills the script
+  process if this is exceeded. Default 400.
+
+.PARAMETER HistoryRetentionEntries
+  Number of historical run entries kept in the state file. Default 20.
+
+.PARAMETER TimeSkewToleranceMinutes
+  Time sync age (minutes since last successful w32tm sync) above which
+  triggers a resync. Default 5.
+
+.PARAMETER BusinessHoursStartHour
+  Hour of day (0-23, device-local time) when business hours start. Default 7.
+
+.PARAMETER BusinessHoursEndHour
+  Hour of day (0-23, device-local time) when business hours end. Default 18.
+
+.PARAMETER MinUptimeMinutes
+  System uptime below this triggers DeviceOffline_RecentReboot. Default 30.
+
+.PARAMETER ForceDisruptiveRepairs
+  Override business-hours gating and allow disruptive repairs immediately.
+  RMM: set NinjaOne script variable ForceDisruptiveRepairs (Checkbox) - read
+  via $env:ForceDisruptiveRepairs per repo convention. CLI switch works for
+  interactive runs.
+
+.PARAMETER ClearStateAndExit
+  Wipe state file and exit without remediation. Used by NOC after manually
+  resolving an underlying issue on a device sitting at MaxAttemptsReached.
+  RMM: set NinjaOne script variable ClearStateAndExit (Checkbox) - read via
+  $env:ClearStateAndExit per repo convention. CLI switch works for
+  interactive runs.
+
+.NOTES
+  Author:    Zachary Boogher, DTC
+  Date:      2026-06-03
+  Version:   8.0
+  Repo:      dtc-inc/msp-script-library
+  Path:      rmm-ninja/lockhart-remediation.ps1
+  Target:    PowerShell 5.1 (NinjaOne)
+  Requires:  LocalSystem / Administrator privileges
+  Runtime:   ~120-180 seconds typical
+  Exit:      0 = success / not applicable / live job skipped / deferred
+             1 = remediation failed or hard blocker
+             2 = max attempts reached, NOC must investigate
+#>
+
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## $RMM - Set to 1 when running from RMM (selects RMMScriptPath log location)
+## $Description - Ticket # or initials for audit trail (optional; defaulted if blank)
+## $ForceDisruptiveRepairs - 1 to override business-hours gating (Checkbox)
+## $ClearStateAndExit - 1 to wipe remediation state file and exit (Checkbox)
+## Optional tuning overrides (advanced; same names as parameters):
+## $SampleSeconds, $ActiveIoThresholdMB, $ActiveCpuThresholdSec,
+## $MaxConsecutiveAttempts, $CounterResetHours, $MinFreeSpacePercent,
+## $NetTestTimeoutMs, $DnsTimeoutMs, $TempCleanupMinAgeDays,
+## $MaxRuntimeSeconds, $HistoryRetentionEntries, $TimeSkewToleranceMinutes,
+## $BusinessHoursStartHour, $BusinessHoursEndHour, $MinUptimeMinutes
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '',
+    Justification = 'All parameters consumed by Invoke-LockhartRemediation via script-scope variable inheritance; PSScriptAnalyzer does not follow control flow into nested function calls.')]
+[CmdletBinding()]
+param(
+    [int]$SampleSeconds            = 90,
+    [int]$ActiveIoThresholdMB      = 10,
+    [double]$ActiveCpuThresholdSec = 5.0,
+    [int]$MaxConsecutiveAttempts   = 2,
+    [int]$CounterResetHours        = 48,
+    [int]$MinFreeSpacePercent      = 10,
+    [int]$NetTestTimeoutMs         = 5000,
+    [int]$DnsTimeoutMs             = 4000,
+    [int]$TempCleanupMinAgeDays    = 7,
+    [int]$MaxRuntimeSeconds        = 400,
+    [int]$HistoryRetentionEntries  = 20,
+    [int]$TimeSkewToleranceMinutes = 5,
+    [int]$BusinessHoursStartHour   = 7,
+    [int]$BusinessHoursEndHour     = 18,
+    [int]$MinUptimeMinutes         = 30,
+    [switch]$ForceDisruptiveRepairs,
+    [switch]$ClearStateAndExit
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+# ============================================================
+# INPUT HANDLING SECTION (per CLAUDE.md / script-template-powershell.ps1)
+# NinjaRMM passes preset variables as ENVIRONMENT variables. Bare param
+# references do not bind from env vars, so every RMM-suppliable value is
+# resolved here: env var wins when present and valid, else the param/default.
+# NOTE (template deviation, deliberate): no Read-Host. This script is
+# condition-triggered automation and must never block on input - a hung
+# prompt would silence backup remediation fleet-wide if the RMM preset
+# were ever missing. Interactive runs use parameter defaults instead.
+# ============================================================
+function Get-RmmInt {
+    param([string]$Name, [int]$Current)
+    $v = [Environment]::GetEnvironmentVariable($Name)
+    if ($v -match '^\d+$') { return [int]$v }
+    return $Current
+}
+
+function Get-RmmDouble {
+    param([string]$Name, [double]$Current)
+    $v = [Environment]::GetEnvironmentVariable($Name)
+    $out = 0.0
+    if (-not [string]::IsNullOrWhiteSpace($v) -and [double]::TryParse($v, [ref]$out)) { return $out }
+    return $Current
+}
+
+function Test-RmmFlag {
+    param([string]$Name)
+    return ([Environment]::GetEnvironmentVariable($Name) -match '^(?i)(1|true|yes|on)$')
+}
+
+# Numeric tunables: env override -> param -> default
+$SampleSeconds            = Get-RmmInt    'SampleSeconds'            $SampleSeconds
+$ActiveIoThresholdMB      = Get-RmmInt    'ActiveIoThresholdMB'      $ActiveIoThresholdMB
+$ActiveCpuThresholdSec    = Get-RmmDouble 'ActiveCpuThresholdSec'    $ActiveCpuThresholdSec
+$MaxConsecutiveAttempts   = Get-RmmInt    'MaxConsecutiveAttempts'   $MaxConsecutiveAttempts
+$CounterResetHours        = Get-RmmInt    'CounterResetHours'        $CounterResetHours
+$MinFreeSpacePercent      = Get-RmmInt    'MinFreeSpacePercent'      $MinFreeSpacePercent
+$NetTestTimeoutMs         = Get-RmmInt    'NetTestTimeoutMs'         $NetTestTimeoutMs
+$DnsTimeoutMs             = Get-RmmInt    'DnsTimeoutMs'             $DnsTimeoutMs
+$TempCleanupMinAgeDays    = Get-RmmInt    'TempCleanupMinAgeDays'    $TempCleanupMinAgeDays
+$MaxRuntimeSeconds        = Get-RmmInt    'MaxRuntimeSeconds'        $MaxRuntimeSeconds
+$HistoryRetentionEntries  = Get-RmmInt    'HistoryRetentionEntries'  $HistoryRetentionEntries
+$TimeSkewToleranceMinutes = Get-RmmInt    'TimeSkewToleranceMinutes' $TimeSkewToleranceMinutes
+$BusinessHoursStartHour   = Get-RmmInt    'BusinessHoursStartHour'   $BusinessHoursStartHour
+$BusinessHoursEndHour     = Get-RmmInt    'BusinessHoursEndHour'     $BusinessHoursEndHour
+$MinUptimeMinutes         = Get-RmmInt    'MinUptimeMinutes'         $MinUptimeMinutes
+
+# NOC checkboxes: env var (NinjaOne UI path) OR CLI switch (interactive path)
+$script:ForceDisruptiveResolved = $ForceDisruptiveRepairs.IsPresent -or (Test-RmmFlag 'ForceDisruptiveRepairs')
+$script:ClearStateResolved      = $ClearStateAndExit.IsPresent      -or (Test-RmmFlag 'ClearStateAndExit')
+
+# Execution context + audit trail (env vars are strings: compare against '1')
+$script:IsRmmMode   = ($env:RMM -eq '1')
+$script:Description = if (-not [string]::IsNullOrWhiteSpace($env:Description)) { $env:Description }
+                      else { 'No description provided (automated condition trigger)' }
+
+# Transcript log path per CLAUDE.md: SYSTEM-context script
+$script:ScriptLogName = 'lockhart-remediation.log'
+if ($script:IsRmmMode -and -not [string]::IsNullOrWhiteSpace($env:RMMScriptPath)) {
+    $script:LogPath = Join-Path $env:RMMScriptPath "logs\$($script:ScriptLogName)"
+} else {
+    $script:LogPath = Join-Path $env:WINDIR "logs\$($script:ScriptLogName)"
+}
+
+# =================== constants ===================
+$script:ServiceName     = 'Lockhart'
+$script:ParentAgentName = 'NinjaRMMAgent'
+$script:MutexName       = 'Global\DTC_NinjaOneBackup_LockhartRemediation_v8'
+$script:CloudEndpoints  = @(
+    @{ Host='app.ninjarmm.com';           Port=443 },
+    @{ Host='backup.ninjarmm.com';        Port=443 },
+    @{ Host='s3.amazonaws.com';           Port=443 },
+    @{ Host='s3.us-east-1.amazonaws.com'; Port=443 }
+)
+$script:OldStateFile = 'C:\ProgramData\DTC\lockhart_autoremediation.json'  # legacy v5/v6 location
+
+# =================== logging ===================
+function Write-DTCLog {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '',
+        Justification = 'NinjaOne captures Write-Host output for script result display; Write-Information is suppressed by default in NinjaOne agent context.')]
+    [CmdletBinding()]
+    param(
+        [ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level,
+        [string]$Message
+    )
+    Write-Host "[$((Get-Date).ToString('yyyy-MM-dd HH:mm:ss'))][$Level] $Message"
+}
+
+# =================== transcript ===================
+function Start-RemediationTranscript {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param()
+    try {
+        $dir = Split-Path $script:LogPath -Parent
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        if ((Test-Path $script:LogPath) -and ((Get-Item $script:LogPath).Length -gt 10MB)) {
+            Move-Item -Path $script:LogPath -Destination "$($script:LogPath).old" -Force
+        }
+        Start-Transcript -Path $script:LogPath -Append -ErrorAction Stop | Out-Null
+        return $true
+    } catch {
+        Write-Verbose "Transcript start failed (continuing without): $_"
+        return $false
+    }
+}
+
+# =================== device class ===================
+function Get-DeviceClass {
+    try {
+        $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+        if ($os.ProductType -in @(2,3)) { return 'Server' }
+        return 'Workstation'
+    } catch {
+        Write-Verbose "Get-DeviceClass failed, defaulting to Workstation: $_"
+        return 'Workstation'
+    }
+}
+
+# =================== paths (resolved after device class detection) ===================
+function Initialize-Path {
+    param([string]$DeviceClass)
+    $base = if ($DeviceClass -eq 'Server') { 'C:\DTC' } else { 'C:\ProgramData\DTC' }
+    $script:StateDir     = $base
+    $script:StateFile    = Join-Path $base 'lockhart_autoremediation.json'
+    $script:ForensicsDir = Join-Path $base 'Forensics'
+}
+
+function Move-LegacyStateFile {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param()
+    if ($script:StateFile -eq $script:OldStateFile) { return }
+    if (Test-Path $script:StateFile) { return }
+    if (-not (Test-Path $script:OldStateFile)) { return }
+    try {
+        if (-not (Test-Path $script:StateDir)) { New-Item -Path $script:StateDir -ItemType Directory -Force | Out-Null }
+        Move-Item -Path $script:OldStateFile -Destination $script:StateFile -Force -ErrorAction Stop
+        Write-DTCLog INFO "Migrated state file from $($script:OldStateFile) to $($script:StateFile)"
+    } catch {
+        Write-Verbose "Legacy state migration failed (continuing with empty state): $_"
+    }
+}
+
+# =================== business hours ===================
+function Test-WithinBusinessHours {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification = '"BusinessHours" is a compound noun for the configured operating window; singular changes meaning.')]
+    param([int]$StartHour, [int]$EndHour)
+    $h = (Get-Date).Hour
+    return ($h -ge $StartHour -and $h -lt $EndHour)
+}
+
+# =================== state file ===================
+function Get-State {
+    if (-not (Test-Path $script:StateDir)) { New-Item -Path $script:StateDir -ItemType Directory -Force | Out-Null }
+    if (Test-Path $script:StateFile) {
+        try {
+            return Get-Content $script:StateFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Write-DTCLog WARN "State file unreadable, resetting: $_"
+        }
+    }
+    return [PSCustomObject]@{
+        ConsecutiveAttempts = 0
+        LastRun             = $null
+        LastResult          = 'Unknown'
+        History             = @()
+    }
+}
+
+function Set-State {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param($State)
+    if ($State.History.Count -gt $HistoryRetentionEntries) {
+        $State.History = @($State.History | Select-Object -First $HistoryRetentionEntries)
+    }
+    try {
+        $State | ConvertTo-Json -Depth 8 | Set-Content -Path $script:StateFile -Encoding UTF8 -ErrorAction Stop
+    } catch {
+        Write-DTCLog ERROR "Failed to write state file: $_"
+    }
+}
+
+# =================== diagnostics ===================
+function Get-SystemUptime {
+    try {
+        $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+        return [math]::Round(((Get-Date) - $os.LastBootUpTime).TotalMinutes, 1)
+    } catch {
+        Write-Verbose "Get-SystemUptime failed: $_"
+        return $null
+    }
+}
+
+function Test-PublicInternet {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '',
+        Justification = '1.1.1.1 (Cloudflare DNS) is the intentional public internet reachability probe, not a managed device.')]
+    [CmdletBinding()]
+    param()
+    try { return [bool](Test-Connection -ComputerName '1.1.1.1' -Count 2 -Quiet -ErrorAction SilentlyContinue) }
+    catch {
+        Write-Verbose "Test-PublicInternet failed: $_"
+        return $false
+    }
+}
+
+function Test-TcpEndpoint {
+    param([string]$TargetHost, [int]$Port, [int]$TimeoutMs)
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $async = $client.BeginConnect($TargetHost, $Port, $null, $null)
+        if (-not $async.AsyncWaitHandle.WaitOne($TimeoutMs, $false)) { return $false }
+        $client.EndConnect($async) | Out-Null
+        return $true
+    } catch {
+        Write-Verbose "Test-TcpEndpoint $TargetHost`:$Port failed: $_"
+        return $false
+    } finally {
+        try { $client.Close() } catch { Write-Verbose "TcpClient close failed (expected during cleanup): $_" }
+    }
+}
+
+function Test-DnsResolutionWithTimeout {
+    param([string]$TargetHost, [int]$TimeoutMs)
+    $ps = [PowerShell]::Create()
+    [void]$ps.AddScript({ param($h) try { [System.Net.Dns]::GetHostAddresses($h) | Out-Null; $true } catch { $false } }).AddArgument($TargetHost)
+    $async = $ps.BeginInvoke()
+    if ($async.AsyncWaitHandle.WaitOne($TimeoutMs)) {
+        try { return [bool]($ps.EndInvoke($async))[0] }
+        catch {
+            Write-Verbose "DNS EndInvoke failed for $TargetHost`: $_"
+            return $false
+        } finally { $ps.Dispose() }
+    } else {
+        try { $ps.Stop() } catch { Write-Verbose "PS.Stop failed for DNS timeout: $_" }
+        $ps.Dispose()
+        return $false
+    }
+}
+
+$script:ServiceCache = @{}
+function Get-ServiceState {
+    param([string]$Name, [switch]$Refresh)
+    if ($Refresh -or -not $script:ServiceCache.ContainsKey($Name)) {
+        $cim = Get-CimInstance Win32_Service -Filter "Name='$Name'" -ErrorAction SilentlyContinue
+        if (-not $cim) {
+            $script:ServiceCache[$Name] = [PSCustomObject]@{
+                Exists=$false; State='NotInstalled'; ProcessId=0; PathName=$null; StartMode=$null
+            }
+        } else {
+            $script:ServiceCache[$Name] = [PSCustomObject]@{
+                Exists=$true; State=$cim.State; ProcessId=$cim.ProcessId
+                PathName=$cim.PathName; StartMode=$cim.StartMode
+            }
+        }
+    }
+    return $script:ServiceCache[$Name]
+}
+
+function Get-ExePathFromService {
+    param($SvcInfo)
+    if (-not $SvcInfo -or -not $SvcInfo.PathName) { return $null }
+    if ($SvcInfo.PathName.StartsWith('"')) {
+        return $SvcInfo.PathName.Substring(1).Split('"')[0]
+    }
+    return ($SvcInfo.PathName -split ' ')[0]
+}
+
+function Get-BinaryVersion {
+    param([string]$Path)
+    try {
+        if (Test-Path $Path) { return (Get-Item $Path).VersionInfo.FileVersion }
+    } catch {
+        Write-Verbose "Get-BinaryVersion failed for $Path`: $_"
+    }
+    return $null
+}
+
+function Test-AgentYaml {
+    param($LockhartSvcInfo)
+    $exe = Get-ExePathFromService -SvcInfo $LockhartSvcInfo
+    if (-not $exe) { return [PSCustomObject]@{ Exists=$false; Readable=$false; Valid=$false; Path=$null } }
+    $yamlPath = Join-Path (Split-Path $exe) 'agent.yaml'
+    if (-not (Test-Path $yamlPath)) {
+        return [PSCustomObject]@{ Exists=$false; Readable=$false; Valid=$false; Path=$yamlPath }
+    }
+    try {
+        $content = Get-Content $yamlPath -Raw -ErrorAction Stop
+        $valid = ($content -match 'logs:') -and ($content -match 'backup:')
+        return [PSCustomObject]@{
+            Exists=$true; Readable=$true; Valid=$valid; Path=$yamlPath
+            SizeBytes=(Get-Item $yamlPath).Length
+        }
+    } catch {
+        Write-Verbose "Test-AgentYaml read failed: $_"
+        return [PSCustomObject]@{ Exists=$true; Readable=$false; Valid=$false; Path=$yamlPath }
+    }
+}
+
+function Get-SystemDriveFreePct {
+    try {
+        $d = Get-PSDrive -Name ($env:SystemDrive[0]) -ErrorAction Stop
+        $total = $d.Used + $d.Free
+        if ($total -le 0) { return $null }
+        return [math]::Round(($d.Free / $total) * 100, 1)
+    } catch {
+        Write-Verbose "Get-SystemDriveFreePct failed: $_"
+        return $null
+    }
+}
+
+function Measure-ProcessActivity {
+    param([int]$TargetPid, [int]$Seconds)
+    $p1 = Get-CimInstance Win32_Process -Filter "ProcessId=$TargetPid" -ErrorAction SilentlyContinue
+    if (-not $p1) { return [PSCustomObject]@{ DeltaMB=0; CpuDeltaSec=0; ProcessAlive=$false } }
+    $r1=[int64]$p1.ReadTransferCount; $w1=[int64]$p1.WriteTransferCount; $o1=[int64]$p1.OtherTransferCount
+    $k1=[int64]$p1.KernelModeTime;    $u1=[int64]$p1.UserModeTime
+    Start-Sleep -Seconds $Seconds
+    $p2 = Get-CimInstance Win32_Process -Filter "ProcessId=$TargetPid" -ErrorAction SilentlyContinue
+    if (-not $p2) { return [PSCustomObject]@{ DeltaMB=0; CpuDeltaSec=0; ProcessAlive=$false } }
+    $deltaBytes = ([int64]$p2.ReadTransferCount - $r1) + ([int64]$p2.WriteTransferCount - $w1) + ([int64]$p2.OtherTransferCount - $o1)
+    $cpuTicks   = ([int64]$p2.KernelModeTime - $k1) + ([int64]$p2.UserModeTime - $u1)
+    return [PSCustomObject]@{
+        DeltaMB      = [math]::Round($deltaBytes/1MB, 2)
+        CpuDeltaSec  = [math]::Round($cpuTicks/10000000, 2)
+        ProcessAlive = $true
+    }
+}
+
+function Get-NetworkForensics {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '',
+        Justification = '1.1.1.1 (Cloudflare DNS) is the intentional public internet reachability probe.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification = '"Forensics" is a collective noun describing aggregated diagnostic output; singular is grammatically incorrect.')]
+    [CmdletBinding()]
+    param()
+    $f = [ordered]@{}
+    try {
+        $gw = (Get-NetRoute -DestinationPrefix '0.0.0.0/0' -ErrorAction SilentlyContinue |
+               Sort-Object RouteMetric | Select-Object -First 1).NextHop
+        $f.DefaultGateway = $gw
+        if ($gw) { $f.GatewayReachable = [bool](Test-Connection -ComputerName $gw -Count 1 -Quiet -ErrorAction SilentlyContinue) }
+    } catch {
+        Write-Verbose "Default gateway probe failed: $_"
+        $f.DefaultGateway = $null
+    }
+    try {
+        $dns = (Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+                Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.InterfaceAlias -notmatch 'Loopback|Bluetooth|isatap' } |
+                Select-Object -First 1).ServerAddresses
+        $f.DnsServers = ($dns -join ',')
+        if ($dns -and $dns.Count -gt 0) {
+            $f.DnsServerReachable = [bool](Test-Connection -ComputerName $dns[0] -Count 1 -Quiet -ErrorAction SilentlyContinue)
+        }
+    } catch {
+        Write-Verbose "DNS server probe failed: $_"
+        $f.DnsServers = $null
+    }
+    try {
+        $proxy = & netsh winhttp show proxy 2>$null | Out-String
+        $f.WinHttpProxy = if ($proxy -match 'Direct access') { 'Direct' }
+                          elseif ($proxy -match 'Proxy Server\(s\)\s*:\s*(\S+)') { $matches[1] }
+                          else { 'Unknown' }
+    } catch {
+        Write-Verbose "WinHTTP proxy query failed: $_"
+        $f.WinHttpProxy = 'QueryFailed'
+    }
+    try {
+        $f.NetworkProfile = (Get-NetConnectionProfile -ErrorAction SilentlyContinue | Select-Object -First 1).NetworkCategory
+    } catch {
+        Write-Verbose "Network profile query failed: $_"
+        $f.NetworkProfile = $null
+    }
+    try {
+        $f.PublicInternetReachable = [bool](Test-Connection -ComputerName '1.1.1.1' -Count 1 -Quiet -ErrorAction SilentlyContinue)
+    } catch {
+        Write-Verbose "Public internet test failed: $_"
+        $f.PublicInternetReachable = $null
+    }
+    return [PSCustomObject]$f
+}
+
+function Get-TimeSyncAge {
+    try {
+        $out = & w32tm /query /status 2>$null | Out-String
+        if ($out -match 'Last Successful Sync Time:\s*(.+)') {
+            $lastSync = [datetime]::Parse($matches[1].Trim())
+            return [math]::Round(((Get-Date) - $lastSync).TotalMinutes, 1)
+        }
+    } catch {
+        Write-Verbose "Time sync age query failed: $_"
+    }
+    return $null
+}
+
+function Get-AvQuarantineEventsForLockhart {
+    try {
+        $cutoff = (Get-Date).AddHours(-24)
+        $events = Get-WinEvent -FilterHashtable @{
+            LogName='Microsoft-Windows-Windows Defender/Operational'
+            Id=@(1116,1117)
+            StartTime=$cutoff
+        } -ErrorAction SilentlyContinue |
+            Where-Object { $_.Message -match 'lockhart|NinjaRMM|ninjarmmagent' }
+        if ($events) {
+            return @($events | ForEach-Object {
+                "$($_.TimeCreated.ToString('s')) ID=$($_.Id) - $($_.Message.Substring(0,[Math]::Min(200,$_.Message.Length)))"
+            })
+        }
+        return @()
+    } catch {
+        Write-Verbose "AV event query failed: $_"
+        return @()
+    }
+}
+
+# =================== repairs ===================
+function Invoke-StartService {
+    param([string]$Name)
+    try {
+        Start-Service -Name $Name -ErrorAction Stop
+        Start-Sleep -Seconds 5
+        return ((Get-Service -Name $Name).Status -eq 'Running')
+    } catch {
+        Write-DTCLog ERROR "Start-Service $Name failed: $_"
+        return $false
+    }
+}
+
+function Invoke-RestartService {
+    param([string]$Name)
+    try {
+        Restart-Service -Name $Name -Force -ErrorAction Stop
+        Start-Sleep -Seconds 5
+        return ((Get-Service -Name $Name).Status -eq 'Running')
+    } catch {
+        Write-DTCLog ERROR "Restart-Service $Name failed: $_"
+        return $false
+    }
+}
+
+function Repair-StoppingService {
+    param([string]$Name)
+    $svc = Get-ServiceState -Name $Name -Refresh
+    if ($svc.State -notin @('Stop Pending','StopPending')) { return $true }
+    Write-DTCLog WARN "REPAIR: $Name stuck in StopPending - force-killing PID $($svc.ProcessId)"
+    if ($svc.ProcessId -gt 0) {
+        try {
+            Stop-Process -Id $svc.ProcessId -Force -ErrorAction Stop
+            Start-Sleep -Seconds 3
+            return $true
+        } catch {
+            Write-DTCLog ERROR "Force-kill PID $($svc.ProcessId) failed: $_"
+            return $false
+        }
+    }
+    return $false
+}
+
+function Repair-DnsCache {
+    Write-DTCLog WARN "REPAIR: Flushing local DNS cache"
+    try { Clear-DnsClientCache -ErrorAction SilentlyContinue; return $true }
+    catch {
+        Write-Verbose "Clear-DnsClientCache failed: $_"
+        return $false
+    }
+}
+
+function Repair-DnsService {
+    Write-DTCLog WARN "REPAIR: Restarting Dnscache service (off-hours operation)"
+    try {
+        Restart-Service -Name 'Dnscache' -Force -ErrorAction Stop
+        Start-Sleep -Seconds 3
+        return $true
+    } catch {
+        Write-DTCLog ERROR "Dnscache restart failed: $_"
+        return $false
+    }
+}
+
+function Repair-ArpCache {
+    Write-DTCLog WARN "REPAIR: Clearing ARP cache (off-hours operation)"
+    try {
+        & arp.exe -d * 2>$null | Out-Null
+        return $true
+    } catch {
+        Write-Verbose "ARP clear failed: $_"
+        return $false
+    }
+}
+
+function Repair-TimeSync {
+    Write-DTCLog WARN "REPAIR: w32tm resync"
+    try {
+        & w32tm /resync /force 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        Write-Verbose "w32tm resync failed: $_"
+        return $false
+    }
+}
+
+function Repair-DiskSpace {
+    param([int]$MinAgeDays)
+    Write-DTCLog WARN "REPAIR: Cleaning Windows\Temp files older than $MinAgeDays days"
+    $cutoff = (Get-Date).AddDays(-$MinAgeDays)
+    $freed = 0
+    $path = "$env:WinDir\Temp"
+    if (-not (Test-Path $path)) { return $true }
+    try {
+        Get-ChildItem -Path $path -File -Recurse -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -lt $cutoff } |
+            ForEach-Object {
+                $sz = $_.Length
+                try {
+                    Remove-Item $_.FullName -Force -ErrorAction Stop
+                    $freed += $sz
+                } catch {
+                    Write-Verbose "Could not delete $($_.FullName): $_"
+                }
+            }
+    } catch {
+        Write-Verbose "Disk cleanup enumeration failed: $_"
+    }
+    Write-DTCLog INFO "Disk cleanup freed: $([math]::Round($freed/1MB,1)) MB"
+    return $true
+}
+
+function Reset-VssStack {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param()
+    Write-DTCLog WARN "REPAIR: VSS stack reset"
+    try {
+        Stop-Service -Name 'VSS'   -Force -ErrorAction SilentlyContinue
+        Stop-Service -Name 'swprv' -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 3
+        Start-Service -Name 'swprv' -ErrorAction Stop
+        Start-Service -Name 'VSS'   -ErrorAction Stop
+        Start-Sleep -Seconds 5
+        return $true
+    } catch {
+        Write-DTCLog ERROR "VSS reset failed: $_"
+        return $false
+    }
+}
+
+function Reset-VssDllRegistration {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param()
+    # BookStack page 2976. Off-hours escalation when VSS stack reset alone doesn't recover.
+    Write-DTCLog WARN "REPAIR (ESCALATION): Re-registering VSS DLLs"
+    try {
+        Stop-Service -Name 'VSS'   -Force -ErrorAction SilentlyContinue
+        Stop-Service -Name 'swprv' -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+        $sys32 = "$env:WinDir\System32"
+        foreach ($d in @('ole32.dll','oleaut32.dll','vss_ps.dll')) {
+            $p = Join-Path $sys32 $d
+            if (Test-Path $p) { & regsvr32.exe /s $p 2>$null }
+        }
+        $swprvDll = Join-Path $sys32 'swprv.dll'
+        if (Test-Path $swprvDll) { & regsvr32.exe /s /i $swprvDll 2>$null }
+        $vssvc = Join-Path $sys32 'vssvc.exe'
+        if (Test-Path $vssvc) { & $vssvc /Register 2>$null }
+        Start-Sleep -Seconds 3
+        Start-Service -Name 'swprv' -ErrorAction SilentlyContinue
+        Start-Service -Name 'VSS'   -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 5
+        return $true
+    } catch {
+        Write-DTCLog ERROR "VSS DLL re-registration failed: $_"
+        return $false
+    }
+}
+
+function Restart-ParentAgent {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Script runs unattended via NinjaOne; ShouldProcess support is dead code in this runtime.')]
+    [CmdletBinding()]
+    param()
+    Write-DTCLog WARN "REPAIR (ESCALATION): Restarting $script:ParentAgentName parent agent"
+    try {
+        Restart-Service -Name $script:ParentAgentName -Force -ErrorAction Stop
+        Start-Sleep -Seconds 15
+        return ((Get-Service -Name $script:ParentAgentName).Status -eq 'Running')
+    } catch {
+        Write-DTCLog ERROR "Parent agent restart failed: $_"
+        return $false
+    }
+}
+
+function Invoke-CollectLogsArchive {
+    Write-DTCLog INFO "FORENSIC: Running ninjarmmagent /collectlogs"
+    $parentSvc = Get-ServiceState -Name $script:ParentAgentName
+    $agentExe = Get-ExePathFromService -SvcInfo $parentSvc
+    if (-not $agentExe -or -not (Test-Path $agentExe)) {
+        Write-DTCLog WARN "Cannot locate ninjarmmagent.exe for /collectlogs"
+        return $null
+    }
+    try {
+        & $agentExe /collectlogs 2>&1 | Out-Null
+        Start-Sleep -Seconds 8
+        $cabSrc = 'C:\Windows\Temp\ninjalogs.cab'
+        if (-not (Test-Path $cabSrc)) {
+            Write-DTCLog WARN "/collectlogs ran but ninjalogs.cab not produced"
+            return $null
+        }
+        if (-not (Test-Path $script:ForensicsDir)) { New-Item -Path $script:ForensicsDir -ItemType Directory -Force | Out-Null }
+        $destFile = Join-Path $script:ForensicsDir "lockhart_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').cab"
+        Copy-Item $cabSrc $destFile -Force
+        Write-DTCLog INFO "Forensic cab archived: $destFile"
+        return $destFile
+    } catch {
+        Write-DTCLog ERROR "/collectlogs forensic capture failed: $_"
+        return $null
+    }
+}
+
+function Get-FullDiagnosis {
+    $lh = Get-ServiceState -Name $script:ServiceName -Refresh
+    $pa = Get-ServiceState -Name $script:ParentAgentName -Refresh
+    $d = [ordered]@{
+        Lockhart        = $lh
+        ParentAgent     = $pa
+        VssSvc          = Get-ServiceState -Name 'VSS' -Refresh
+        SwprvSvc        = Get-ServiceState -Name 'swprv' -Refresh
+        FreeSpacePct    = Get-SystemDriveFreePct
+        FailedDns       = @()
+        FailedTcp       = @()
+        TimeSyncAgeMin  = Get-TimeSyncAge
+        AvEvents        = Get-AvQuarantineEventsForLockhart
+        BinaryExists    = $false
+        LockhartVersion = $null
+        AgentVersion    = $null
+        AgentYaml       = $null
+    }
+    if ($lh.Exists) {
+        $lockhartExe = Get-ExePathFromService -SvcInfo $lh
+        $d.BinaryExists = if ($lockhartExe) { Test-Path $lockhartExe } else { $false }
+        $d.LockhartVersion = Get-BinaryVersion -Path $lockhartExe
+        $d.AgentYaml = Test-AgentYaml -LockhartSvcInfo $lh
+    }
+    if ($pa.Exists) {
+        $d.AgentVersion = Get-BinaryVersion -Path (Get-ExePathFromService -SvcInfo $pa)
+    }
+    foreach ($ep in $script:CloudEndpoints) {
+        if (-not (Test-DnsResolutionWithTimeout -TargetHost $ep.Host -TimeoutMs $DnsTimeoutMs)) {
+            $d.FailedDns += $ep.Host
+        }
+    }
+    foreach ($ep in $script:CloudEndpoints) {
+        if ($d.FailedDns -contains $ep.Host) { continue }
+        if (-not (Test-TcpEndpoint -TargetHost $ep.Host -Port $ep.Port -TimeoutMs $NetTestTimeoutMs)) {
+            $d.FailedTcp += "$($ep.Host):$($ep.Port)"
+        }
+    }
+    return [PSCustomObject]$d
+}
+
+# =================== completion (terminal helper) ===================
+function Complete-Remediation {
+    param($State, [string]$Result, [int]$Code, [PSCustomObject]$Entry)
+    $State.LastRun = (Get-Date).ToString('o')
+    $State.LastResult = $Result
+    if ($Entry) {
+        $State.History = @(@($Entry) + @($State.History))
+    }
+    Set-State $State
+    Write-DTCLog INFO "=== EXIT: $Result ==="
+    return $Code
+}
+
+# =================== main flow (function-wrapped for Pester testability) ===================
+function Invoke-LockhartRemediation {
+    [CmdletBinding()]
+    param()
+
+    $runTs = Get-Date
+    Write-DTCLog INFO "=== NinjaOne Backup - Lockhart Remediation / Repair v8 ==="
+    Write-DTCLog INFO "Host: $env:COMPUTERNAME | PS: $($PSVersionTable.PSVersion) | PID: $PID"
+
+    # Defense-in-depth: entry point already checks ^HV0 before transcript;
+    # this guards direct function invocation in future refactors.
+    if ($env:COMPUTERNAME -match '^HV0') {
+        Write-DTCLog INFO "Hyper-V host detected ($env:COMPUTERNAME matches ^HV0). Backup remediation does not apply to hypervisors. Skipping."
+        Write-DTCLog INFO "=== EXIT: HypervisorSkip ==="
+        return 0
+    }
+
+    # ============================================================
+    # PHASE 1: CHECK
+    # ============================================================
+    $inBusinessHours = Test-WithinBusinessHours -StartHour $BusinessHoursStartHour -EndHour $BusinessHoursEndHour
+    $disruptiveAllowed = (-not $inBusinessHours) -or $script:ForceDisruptiveResolved
+    Write-DTCLog INFO "Time: $((Get-Date).ToString('HH:mm')) | BusinessHours($BusinessHoursStartHour-$BusinessHoursEndHour): $inBusinessHours | DisruptiveAllowed: $disruptiveAllowed"
+
+    $deviceClass = Get-DeviceClass
+    Initialize-Path -DeviceClass $deviceClass
+    Move-LegacyStateFile
+    Write-DTCLog INFO "DeviceClass: $deviceClass | StateFile: $($script:StateFile)"
+
+    # ClearStateAndExit short-circuit (env var via NinjaOne checkbox, or CLI switch)
+    if ($script:ClearStateResolved) {
+        Write-DTCLog INFO "ClearStateAndExit requested (param=$($ClearStateAndExit.IsPresent), env='$($env:ClearStateAndExit)')"
+        if (Test-Path $script:StateFile) {
+            try {
+                Remove-Item $script:StateFile -Force -ErrorAction Stop
+                Write-DTCLog INFO "State file removed: $($script:StateFile)"
+            } catch {
+                Write-DTCLog ERROR "Failed to remove state file: $_"
+                return 1
+            }
+        } else {
+            Write-DTCLog INFO "No state file to clear"
+        }
+        Write-DTCLog INFO "=== EXIT: StateCleared ==="
+        return 0
+    }
+
+    # Lockhart service must exist
+    $svc = Get-ServiceState -Name $script:ServiceName
+    if (-not $svc.Exists) {
+        Write-DTCLog INFO "Service '$script:ServiceName' not installed. NinjaOne Backup not enabled on this device. Skipping."
+        Write-DTCLog INFO "=== EXIT: NotApplicable ==="
+        return 0
+    }
+
+    # Device-offline short-circuits (sole reason, no counter increment)
+    $uptimeMin = Get-SystemUptime
+    $publicInternet = Test-PublicInternet
+    Write-DTCLog INFO "UptimeMin: $uptimeMin | PublicInternet: $publicInternet"
+
+    $state = Get-State
+
+    if (-not $publicInternet) {
+        Write-DTCLog WARN "Device cannot reach public internet (1.1.1.1). Sole reason for backup failure: device offline. No remediation attempted."
+        $entry = [PSCustomObject]@{
+            Time=$runTs.ToString('o'); DeviceClass=$deviceClass; InBusinessHours=$inBusinessHours
+            Result='DeviceOffline_NoInternet'; Actions=''; Deferred=''; Failures=''
+            Reason='Device cannot reach public internet'
+            UptimeMin=$uptimeMin; PublicInternetReachable=$false
+        }
+        return Complete-Remediation -State $state -Result 'DeviceOffline_NoInternet' -Code 0 -Entry $entry
+    }
+
+    if ($null -ne $uptimeMin -and $uptimeMin -lt $MinUptimeMinutes) {
+        Write-DTCLog WARN "Device uptime is $uptimeMin minutes (< $MinUptimeMinutes). Likely missed scheduled backup window due to recent reboot. Sole reason: device offline."
+        $entry = [PSCustomObject]@{
+            Time=$runTs.ToString('o'); DeviceClass=$deviceClass; InBusinessHours=$inBusinessHours
+            Result='DeviceOffline_RecentReboot'; Actions=''; Deferred=''; Failures=''
+            Reason="Device uptime $uptimeMin min (< $MinUptimeMinutes); likely missed backup window"
+            UptimeMin=$uptimeMin; PublicInternetReachable=$true
+        }
+        return Complete-Remediation -State $state -Result 'DeviceOffline_RecentReboot' -Code 0 -Entry $entry
+    }
+
+    # Counter auto-reset
+    if ($state.LastRun) {
+        $hoursSince = ((Get-Date) - [datetime]$state.LastRun).TotalHours
+        if ($hoursSince -gt $CounterResetHours) {
+            Write-DTCLog INFO "Last run $([math]::Round($hoursSince,1))h ago (> $CounterResetHours h) - resetting counter"
+            $state.ConsecutiveAttempts = 0
+        }
+    }
+    Write-DTCLog INFO "State: Attempts=$($state.ConsecutiveAttempts) | LastResult=$($state.LastResult) | LastRun=$($state.LastRun)"
+
+    # Guardrail - counter tracks interventions (successful or not) within the window
+    if ([int]$state.ConsecutiveAttempts -ge $MaxConsecutiveAttempts) {
+        $reason = "$($state.ConsecutiveAttempts) consecutive remediation interventions within the ${CounterResetHours}h window. Last result: $($state.LastResult). Repeated intervention - even when each one succeeds - indicates an underlying issue the script cannot fix. NOC must investigate manually."
+        Write-DTCLog ERROR $reason
+        return Complete-Remediation -State $state -Result 'MaxAttemptsReached' -Code 2 -Entry $null
+    }
+
+    # ============================================================
+    # PHASE 2: DIAGNOSE
+    # ============================================================
+    Write-DTCLog INFO "--- Phase 2: DIAGNOSE ---"
+    $diag = Get-FullDiagnosis
+    Write-DTCLog INFO "Lockhart: $($diag.Lockhart.State) PID=$($diag.Lockhart.ProcessId) BinaryExists=$($diag.BinaryExists) Ver=$($diag.LockhartVersion)"
+    Write-DTCLog INFO "$script:ParentAgentName: $($diag.ParentAgent.State) Ver=$($diag.AgentVersion) | VSS: $($diag.VssSvc.State) | swprv: $($diag.SwprvSvc.State)"
+    Write-DTCLog INFO "Free disk: $($diag.FreeSpacePct)% | TimeSyncAge: $($diag.TimeSyncAgeMin) min | AvEvents: $($diag.AvEvents.Count)"
+    if ($diag.AgentYaml) {
+        Write-DTCLog INFO "agent.yaml: Exists=$($diag.AgentYaml.Exists) Readable=$($diag.AgentYaml.Readable) Valid=$($diag.AgentYaml.Valid)"
+    }
+    Write-DTCLog INFO "DNS failed: $($diag.FailedDns.Count) [$($diag.FailedDns -join ',')] | TCP failed: $($diag.FailedTcp.Count) [$($diag.FailedTcp -join ',')]"
+
+    # Hard blockers (no remediation possible from script)
+    $hardBlocker = $null
+    $blockerResult = $null
+    if (-not $diag.BinaryExists -and $diag.Lockhart.PathName) {
+        $hardBlocker = "BinaryMissing: Lockhart service exists but binary not found at $($diag.Lockhart.PathName). Agent reinstall required."
+        $blockerResult = 'RemediationBlocked_BinaryMissing'
+    } elseif ($diag.AgentYaml -and $diag.AgentYaml.Exists -and -not $diag.AgentYaml.Valid) {
+        $hardBlocker = "agent.yaml at $($diag.AgentYaml.Path) is missing required sections. Agent reinstall required."
+        $blockerResult = 'RemediationBlocked_ConfigCorrupt'
+    } elseif ($diag.AgentYaml -and -not $diag.AgentYaml.Exists -and $diag.AgentYaml.Path) {
+        $hardBlocker = "agent.yaml not found at $($diag.AgentYaml.Path). Lockhart install incomplete - reinstall required."
+        $blockerResult = 'RemediationBlocked_ConfigMissing'
+    } elseif ($diag.AvEvents.Count -gt 0) {
+        $hardBlocker = "AV quarantined Lockhart in last 24h. AV exclusion required at vendor console. Events: $($diag.AvEvents -join ' || ')"
+        $blockerResult = 'RemediationBlocked_AvQuarantine'
+    }
+    if ($hardBlocker) {
+        Write-DTCLog ERROR $hardBlocker
+        $netForensics = Get-NetworkForensics
+        $cabPath = Invoke-CollectLogsArchive
+        $state.ConsecutiveAttempts = [int]$state.ConsecutiveAttempts + 1
+        $entry = [PSCustomObject]@{
+            Time=$runTs.ToString('o'); DeviceClass=$deviceClass; InBusinessHours=$inBusinessHours
+            Result=$blockerResult; Actions=''; Deferred=''
+            Failures=$blockerResult.Replace('RemediationBlocked_',''); Reason=$hardBlocker
+            Forensics=$netForensics; ForensicCab=$cabPath
+            LockhartVersion=$diag.LockhartVersion; AgentVersion=$diag.AgentVersion
+            AvEvents = if ($diag.AvEvents.Count -gt 0) { $diag.AvEvents } else { $null }
+        }
+        return Complete-Remediation -State $state -Result $blockerResult -Code 1 -Entry $entry
+    }
+
+    # Live backup detection
+    $liveBackup = $null
+    if ($diag.Lockhart.State -eq 'Running' -and $diag.Lockhart.ProcessId -gt 0 -and (Get-Process -Id $diag.Lockhart.ProcessId -ErrorAction SilentlyContinue)) {
+        Write-DTCLog INFO "Sampling PID=$($diag.Lockhart.ProcessId) for $SampleSeconds seconds"
+        $liveBackup = Measure-ProcessActivity -TargetPid $diag.Lockhart.ProcessId -Seconds $SampleSeconds
+        Write-DTCLog INFO "Sample: IO=$($liveBackup.DeltaMB) MB | CPU=$($liveBackup.CpuDeltaSec)s | Alive=$($liveBackup.ProcessAlive)"
+        if ($liveBackup.ProcessAlive -and ($liveBackup.DeltaMB -ge $ActiveIoThresholdMB -or $liveBackup.CpuDeltaSec -ge $ActiveCpuThresholdSec)) {
+            Write-DTCLog INFO "LIVE BACKUP DETECTED - exiting without remediation"
+            $entry = [PSCustomObject]@{
+                Time=$runTs.ToString('o'); DeviceClass=$deviceClass; InBusinessHours=$inBusinessHours
+                Result='LiveJobSkipped'; Actions=''; Deferred=''; Failures=''
+                Reason='Live backup in progress'
+            }
+            return Complete-Remediation -State $state -Result 'LiveJobSkipped' -Code 0 -Entry $entry
+        }
+    }
+
+    # ============================================================
+    # PHASE 3: REPAIR
+    # ============================================================
+    Write-DTCLog INFO "--- Phase 3: REPAIR (DisruptiveAllowed=$disruptiveAllowed) ---"
+    $repairActions = @()
+    $deferredRepairs = @()
+
+    # Anytime: DNS cache flush
+    if ($diag.FailedDns.Count -gt 0 -or $diag.FailedTcp.Count -gt 0) {
+        if (Repair-DnsCache) { $repairActions += 'DnsCacheFlushed' }
+    }
+
+    # Anytime: time resync
+    if ($null -ne $diag.TimeSyncAgeMin -and $diag.TimeSyncAgeMin -gt $TimeSkewToleranceMinutes) {
+        if (Repair-TimeSync) { $repairActions += 'TimeResynced' } else { $repairActions += 'Failed_TimeResync' }
+    }
+
+    # Anytime: disk cleanup
+    if ($null -ne $diag.FreeSpacePct -and $diag.FreeSpacePct -lt $MinFreeSpacePercent) {
+        if (Repair-DiskSpace -MinAgeDays $TempCleanupMinAgeDays) { $repairActions += 'DiskSpaceCleaned' }
+    }
+
+    # Gated: Dnscache restart
+    if ($diag.FailedDns.Count -gt 0) {
+        if ($disruptiveAllowed) {
+            if (Repair-DnsService) { $repairActions += 'DnsServiceRestarted' } else { $repairActions += 'Failed_DnsServiceRestart' }
+        } else {
+            Write-DTCLog INFO "DEFER: Dnscache restart (business hours)"
+            $deferredRepairs += 'DnsServiceRestart'
+        }
+    }
+
+    # Gated: ARP clear
+    if ($diag.FailedTcp.Count -gt 0) {
+        if ($disruptiveAllowed) {
+            if (Repair-ArpCache) { $repairActions += 'ArpCacheCleared' }
+        } else {
+            Write-DTCLog INFO "DEFER: ARP clear (business hours)"
+            $deferredRepairs += 'ArpCacheClear'
+        }
+    }
+
+    # Anytime: parent agent start (Lockhart depends on it)
+    if ($diag.ParentAgent.Exists -and $diag.ParentAgent.State -ne 'Running') {
+        Write-DTCLog WARN "REPAIR: Starting $script:ParentAgentName"
+        if (Invoke-StartService -Name $script:ParentAgentName) { $repairActions += "Started_$script:ParentAgentName" }
+        else { $repairActions += "Failed_Start_$script:ParentAgentName" }
+        Start-Sleep -Seconds 3
+    }
+
+    # Anytime: VSS stack reset (if either service is non-normal)
+    $vssOk   = $diag.VssSvc.State -in @('Running','Stopped')
+    $swprvOk = $diag.SwprvSvc.State -in @('Running','Stopped')
+    $vssWasBad = -not ($vssOk -and $swprvOk)
+    if ($vssWasBad) {
+        if (Reset-VssStack) { $repairActions += 'VssStackReset' } else { $repairActions += 'Failed_VssReset' }
+    }
+
+    # Anytime: Lockhart action based on observed state
+    $currentSvc = Get-ServiceState -Name $script:ServiceName -Refresh
+    if ($currentSvc.State -in @('Stop Pending','StopPending','StartPending','Start Pending')) {
+        Write-DTCLog WARN "Lockhart wedged in $($currentSvc.State) - force-killing"
+        if (Repair-StoppingService -Name $script:ServiceName) { $repairActions += 'LockhartForceKilled' }
+        $currentSvc = Get-ServiceState -Name $script:ServiceName -Refresh
+    }
+    switch ($currentSvc.State) {
+        'Stopped' {
+            if (Invoke-StartService -Name $script:ServiceName) { $repairActions += 'LockhartStarted' }
+            else { $repairActions += 'Failed_LockhartStart' }
+        }
+        'Paused' {
+            if (Invoke-RestartService -Name $script:ServiceName) { $repairActions += 'LockhartRestarted' }
+            else { $repairActions += 'Failed_LockhartRestart' }
+        }
+        'Running' {
+            # Single restart for every Running sub-state that reaches this point:
+            #  - zombie PID / process missing
+            #  - process died during the sample window
+            #  - process alive but idle below both thresholds with backups failing 25h+
+            # A genuinely active backup already exited earlier via LiveJobSkipped.
+            # Known accepted edge: a long-running backup sampled entirely within a
+            # quiet phase (dedupe/catalog/network stall) gets restarted; NinjaOne
+            # Backup resumes block-level on the next run (vendor-documented), so
+            # the cost is bounded and preferable to leaving stuck processes
+            # unremediated - the exact case the pilot validated.
+            if (Invoke-RestartService -Name $script:ServiceName) { $repairActions += 'LockhartRestarted' }
+            else { $repairActions += 'Failed_LockhartRestart' }
+        }
+        default {
+            if (Invoke-RestartService -Name $script:ServiceName) { $repairActions += 'LockhartRestarted' }
+            else { $repairActions += 'Failed_LockhartRestart' }
+        }
+    }
+
+    # ============================================================
+    # MID-CONFIRM (decide if escalation needed)
+    # ============================================================
+    Start-Sleep -Seconds 3
+    $mid = Get-FullDiagnosis
+    $vssStillBad      = -not (($mid.VssSvc.State -in @('Running','Stopped')) -and ($mid.SwprvSvc.State -in @('Running','Stopped')))
+    $lockhartStillBad = $mid.Lockhart.State -ne 'Running'
+
+    # ============================================================
+    # ESCALATION REPAIRS (off-hours only)
+    # ============================================================
+    if ($vssWasBad -and $vssStillBad) {
+        if ($disruptiveAllowed) {
+            Write-DTCLog WARN "VSS still bad after stack reset - escalating to DLL re-registration"
+            if (Reset-VssDllRegistration) { $repairActions += 'VssDllReRegistered' }
+            else { $repairActions += 'Failed_VssDllReReg' }
+        } else {
+            Write-DTCLog INFO "DEFER: VSS DLL re-registration (escalation, business hours)"
+            $deferredRepairs += 'VssDllReRegistration'
+        }
+    }
+    if ($lockhartStillBad) {
+        if ($disruptiveAllowed) {
+            Write-DTCLog WARN "Lockhart still not Running after restart - escalating to parent agent restart"
+            if (Restart-ParentAgent) {
+                $repairActions += 'ParentAgentRestarted'
+                Start-Sleep -Seconds 10
+                $finalSvc = Get-ServiceState -Name $script:ServiceName -Refresh
+                if ($finalSvc.State -ne 'Running') {
+                    if (Invoke-StartService -Name $script:ServiceName) { $repairActions += 'LockhartStarted_PostAgentRestart' }
+                }
+            } else { $repairActions += 'Failed_ParentAgentRestart' }
+        } else {
+            Write-DTCLog INFO "DEFER: NinjaRMMAgent restart (escalation, business hours)"
+            $deferredRepairs += 'ParentAgentRestart'
+        }
+    }
+
+    # ============================================================
+    # PHASE 4: FINAL CONFIRM
+    # ============================================================
+    Write-DTCLog INFO "--- Phase 4: CONFIRM ---"
+    Start-Sleep -Seconds 3
+    $post = Get-FullDiagnosis
+    $confirmFailures = @()
+    if ($post.Lockhart.State -ne 'Running') { $confirmFailures += "Lockhart_Not_Running($($post.Lockhart.State))" }
+    if ($post.ParentAgent.Exists -and $post.ParentAgent.State -ne 'Running') { $confirmFailures += "ParentAgent_Not_Running($($post.ParentAgent.State))" }
+    if ($post.FailedDns.Count -gt 0) { $confirmFailures += "DNS_Still_Failing($($post.FailedDns -join ','))" }
+    if ($post.FailedTcp.Count -gt 0) { $confirmFailures += "Cloud_Still_Unreachable($($post.FailedTcp -join ','))" }
+    if ($null -ne $post.FreeSpacePct -and $post.FreeSpacePct -lt $MinFreeSpacePercent) {
+        $confirmFailures += "DiskSpace_Still_Low($($post.FreeSpacePct)%)"
+    }
+    Write-DTCLog INFO "Post-repair: Lockhart=$($post.Lockhart.State) | DNS-fail=$($post.FailedDns.Count) | TCP-fail=$($post.FailedTcp.Count) | Disk=$($post.FreeSpacePct)%"
+
+    $forensics = $null
+    $cabPath = $null
+    if ($confirmFailures.Count -gt 0) {
+        $forensics = Get-NetworkForensics
+        Write-DTCLog INFO "Forensics: Gateway=$($forensics.DefaultGateway) reach=$($forensics.GatewayReachable) | DNS=$($forensics.DnsServers) reach=$($forensics.DnsServerReachable) | Proxy=$($forensics.WinHttpProxy) | Internet=$($forensics.PublicInternetReachable)"
+    }
+
+    # ============================================================
+    # PHASE 5: STATE (record outcome)
+    # ============================================================
+    $deferredCouldFix = ($deferredRepairs.Count -gt 0) -and ($confirmFailures.Count -gt 0)
+    $result = $null
+
+    if ($confirmFailures.Count -eq 0) {
+        if ($repairActions.Count -eq 0) {
+            $result = 'AlreadyHealthy_CounterCleared'
+            $state.ConsecutiveAttempts = 0
+            Write-DTCLog INFO "Lockhart fully healthy, no repairs needed. Counter cleared."
+        } else {
+            # Intentional: successful interventions still count toward the
+            # guardrail. Needing to repair Lockhart every cycle is a recurring
+            # problem worth NOC eyes even when each individual repair works.
+            # AlreadyHealthy_CounterCleared (above) is the recovery path once
+            # the device holds healthy between runs.
+            $result = 'RemediationSucceeded'
+            $state.ConsecutiveAttempts = [int]$state.ConsecutiveAttempts + 1
+            Write-DTCLog INFO "Repairs confirmed healthy. Actions: $($repairActions -join ', ')"
+        }
+    } elseif ($deferredCouldFix) {
+        $result = 'RemediationDeferred'
+        Write-DTCLog WARN "Confirm failed but disruptive repairs deferred. Counter NOT incremented. Deferred: $($deferredRepairs -join ', ') | Unresolved: $($confirmFailures -join ' | ')"
+    } else {
+        $result = 'RemediationFailed'
+        $state.ConsecutiveAttempts = [int]$state.ConsecutiveAttempts + 1
+        Write-DTCLog ERROR "Repair did not fully confirm. Unresolved: $($confirmFailures -join ' | ')"
+        $cabPath = Invoke-CollectLogsArchive
+    }
+
+    $entry = [PSCustomObject]@{
+        Time            = $runTs.ToString('o')
+        DeviceClass     = $deviceClass
+        InBusinessHours = $inBusinessHours
+        Result          = $result
+        Actions         = ($repairActions -join ',')
+        Deferred        = ($deferredRepairs -join ',')
+        Failures        = ($confirmFailures -join ',')
+        Reason          = if ($confirmFailures.Count -gt 0) { $confirmFailures -join ' | ' } else { 'OK' }
+        Forensics       = $forensics
+        ForensicCab     = $cabPath
+        LockhartVersion = $diag.LockhartVersion
+        AgentVersion    = $diag.AgentVersion
+    }
+
+    Write-DTCLog INFO "Final: ConsecutiveAttempts=$($state.ConsecutiveAttempts) | Result=$result"
+
+    $exitCode = switch ($result) {
+        'AlreadyHealthy_CounterCleared' { 0 }
+        'RemediationSucceeded'          { 0 }
+        'RemediationDeferred'           { 0 }
+        'RemediationFailed'             { 1 }
+        default                         { 1 }
+    }
+    return Complete-Remediation -State $state -Result $result -Code $exitCode -Entry $entry
+}
+
+# ================================================================
+# ENTRY POINT (SCRIPT LOGIC SECTION)
+# ================================================================
+# HV0 exclusion FIRST - before transcript, mutex, or any file writes.
+# Hypervisors take zero side effects from this script.
+if ($env:COMPUTERNAME -match '^HV0') {
+    Write-DTCLog INFO "Hyper-V host detected ($env:COMPUTERNAME matches ^HV0). Backup remediation does not apply to hypervisors. Skipping."
+    Write-DTCLog INFO "=== EXIT: HypervisorSkip ==="
+    exit 0
+}
+
+$script:TranscriptActive = Start-RemediationTranscript
+Write-DTCLog INFO "Description: $($script:Description) | RMM mode: $($script:IsRmmMode) | LogPath: $($script:LogPath)"
+Write-DTCLog INFO "Flags: ForceDisruptiveRepairs param=$($ForceDisruptiveRepairs.IsPresent) env='$($env:ForceDisruptiveRepairs)' resolved=$($script:ForceDisruptiveResolved) | ClearStateAndExit param=$($ClearStateAndExit.IsPresent) env='$($env:ClearStateAndExit)' resolved=$($script:ClearStateResolved)"
+
+$scriptPid = $PID
+$scriptTimeout = $MaxRuntimeSeconds
+$runtimeKiller = Start-Job -ScriptBlock {
+    Start-Sleep -Seconds $using:scriptTimeout
+    try { Stop-Process -Id $using:scriptPid -Force -ErrorAction SilentlyContinue } catch { Write-Verbose "Runtime killer Stop-Process failed: $_" }
+}
+
+$script:mutex = $null
+$exitCode = 1
+try {
+    $script:mutex = New-Object System.Threading.Mutex($false, $script:MutexName)
+    if (-not $script:mutex.WaitOne(0)) {
+        Write-DTCLog WARN "Another instance already running. Exiting."
+        $exitCode = 0
+    } else {
+        $exitCode = Invoke-LockhartRemediation
+    }
+} catch {
+    Write-DTCLog ERROR "Unhandled exception: $_"
+    Write-DTCLog ERROR $_.ScriptStackTrace
+    $exitCode = 1
+} finally {
+    if ($script:mutex) {
+        try { $script:mutex.ReleaseMutex() } catch { Write-Verbose "Mutex release failed: $_" }
+        try { $script:mutex.Dispose() } catch { Write-Verbose "Mutex dispose failed: $_" }
+    }
+    Stop-Job $runtimeKiller -ErrorAction SilentlyContinue | Out-Null
+    Remove-Job $runtimeKiller -Force -ErrorAction SilentlyContinue | Out-Null
+    if ($script:TranscriptActive) {
+        try { Stop-Transcript | Out-Null } catch { Write-Verbose "Stop-Transcript failed: $_" }
+    }
+}
+
+exit $exitCode

--- a/rmm-ninja/lockhart-remediation.ps1
+++ b/rmm-ninja/lockhart-remediation.ps1
@@ -257,7 +257,6 @@ $script:ParentAgentName = 'NinjaRMMAgent'
 $script:MutexName       = 'Global\DTC_NinjaOneBackup_LockhartRemediation_v8'
 $script:CloudEndpoints  = @(
     @{ Host='app.ninjarmm.com';           Port=443 },
-    @{ Host='backup.ninjarmm.com';        Port=443 },
     @{ Host='s3.amazonaws.com';           Port=443 },
     @{ Host='s3.us-east-1.amazonaws.com'; Port=443 }
 )

--- a/rmm-ninja/ninja-ensure-device-guid.ps1
+++ b/rmm-ninja/ninja-ensure-device-guid.ps1
@@ -1,0 +1,207 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM                    - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description            - Ticket # or initials for audit trail
+## $env:RMMScriptPath          - Optional log directory base provided by the RMM
+## $env:CustomFieldDeviceGuid  - NinjaOne device text field API name for the device OUID (default: "deviceGuid")
+##
+## Ensures this device has a DTC Operational UUID (OUID), the "Device GUID".
+## Mints a UUIDv7 ONCE and persists it in two places per the DTC OUID Standard:
+##   - On-device:  registry HKLM\SOFTWARE\DTC\DeviceGuid (self-identify without network)
+##   - NinjaOne:   device custom field (authoritative source of truth)
+##
+## Idempotent and self-healing -- safe to run on every boot:
+##   - Both present and equal      -> nothing to do, exit 0.
+##   - Both present but DIFFERENT   -> conflict, never overwrite an assigned OUID, exit 1.
+##   - Only one present             -> backfill the other from it, exit 0.
+##   - Neither present              -> mint a new UUIDv7, write both, exit 0.
+##
+## The device OUID is assigned once and never changes (DTC OUID Standard). It is
+## the stable, recomputable identity that downstream provisioning (e.g. the Veeam
+## S3 repo folder) depends on. Run this BEFORE any script that reads the Device GUID.
+##
+## Requires SYSTEM/admin context: writes HKLM and calls Ninja-Property-Set/Get
+## (which only work in SYSTEM context). Configure as a boot trigger in NinjaOne.
+
+$ScriptLogName = "ninja-ensure-device-guid.log"
+$GuidRegex = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+$RegPath = "HKLM:\SOFTWARE\DTC"
+$RegValueName = "DeviceGuid"
+
+# --- Default optional RMM environment variables --------------------------
+
+if ([string]::IsNullOrEmpty($env:CustomFieldDeviceGuid)) {
+    $env:CustomFieldDeviceGuid = "deviceGuid"
+}
+
+# --- Helper functions ----------------------------------------------------
+
+function New-UuidV7 {
+    # Generates a UUIDv7 (RFC 9562) as a lowercase dashed string.
+    # Prefers the runtime's native generator (.NET 9+); otherwise builds it by
+    # hand so the script has no dependency on Node/Python/newer .NET.
+    try {
+        $method = [System.Guid].GetMethod('CreateVersion7', [Type]::EmptyTypes)
+        if ($method) {
+            return ([System.Guid]::CreateVersion7()).ToString().ToLower()
+        }
+    } catch { }
+
+    # Manual RFC 9562 layout:
+    #   48 bits Unix epoch ms (big-endian) | 4 bits version 0x7 | 12 bits random
+    #   | 2 bits variant 0b10 | 62 bits random
+    $unixMs = [long][System.DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+
+    $bytes = New-Object 'System.Byte[]' 16
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
+
+    # Timestamp into the first 6 bytes, most-significant first.
+    $bytes[0] = [byte](($unixMs -shr 40) -band 0xFF)
+    $bytes[1] = [byte](($unixMs -shr 32) -band 0xFF)
+    $bytes[2] = [byte](($unixMs -shr 24) -band 0xFF)
+    $bytes[3] = [byte](($unixMs -shr 16) -band 0xFF)
+    $bytes[4] = [byte](($unixMs -shr 8)  -band 0xFF)
+    $bytes[5] = [byte]( $unixMs          -band 0xFF)
+
+    # Version 7 in the high nibble of byte 6; variant 0b10 in the high bits of byte 8.
+    $bytes[6] = [byte](($bytes[6] -band 0x0F) -bor 0x70)
+    $bytes[8] = [byte](($bytes[8] -band 0x3F) -bor 0x80)
+
+    # Build the string manually. [System.Guid](byte[]) reads the first three
+    # groups little-endian, which would scramble our big-endian timestamp, so
+    # format straight from the hex instead.
+    $hex = (($bytes | ForEach-Object { $_.ToString('x2') }) -join '')
+    return ("{0}-{1}-{2}-{3}-{4}" -f `
+        $hex.Substring(0, 8), $hex.Substring(8, 4), $hex.Substring(12, 4), `
+        $hex.Substring(16, 4), $hex.Substring(20, 12))
+}
+
+function Get-RegistryGuid {
+    try {
+        $item = Get-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction Stop
+        $val = "$($item.$RegValueName)"
+        if ($val -match $GuidRegex) { return $val.ToLower() }
+    } catch { }
+    return $null
+}
+
+function Set-RegistryGuid {
+    param([string]$Value)
+    if (-not (Test-Path $RegPath)) {
+        New-Item -Path $RegPath -Force | Out-Null
+    }
+    New-ItemProperty -Path $RegPath -Name $RegValueName -Value $Value -PropertyType String -Force | Out-Null
+}
+
+function Get-NinjaGuid {
+    if (-not (Get-Command "Ninja-Property-Get" -ErrorAction SilentlyContinue)) { return $null }
+    try {
+        $val = "$(Ninja-Property-Get $env:CustomFieldDeviceGuid 2>$null)"
+        if ($val -match $GuidRegex) { return $val.ToLower() }
+    } catch { }
+    return $null
+}
+
+function Set-NinjaGuid {
+    param([string]$Value)
+    if (-not (Get-Command "Ninja-Property-Set" -ErrorAction SilentlyContinue)) {
+        Write-Host "  [SKIP] Ninja-Property-Set not available (not SYSTEM context). Skipped NinjaOne write."
+        return $false
+    }
+    try {
+        Ninja-Property-Set $env:CustomFieldDeviceGuid $Value
+        Write-Host "  [OK] NinjaOne field '$env:CustomFieldDeviceGuid' = $Value"
+        return $true
+    } catch {
+        Write-Warning "  Failed to write NinjaOne field: $_"
+        return $false
+    }
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    while ($ValidInput -ne 1) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "No Description"
+    }
+}
+
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+Start-Transcript -Path $LogPath
+
+Write-Host "=== Ensure Device OUID (Device GUID) ==="
+Write-Host "Description:  $env:Description"
+Write-Host "Log path:     $LogPath"
+Write-Host "RMM:          $env:RMM"
+Write-Host "Ninja field:  $env:CustomFieldDeviceGuid"
+Write-Host ""
+
+$regGuid = Get-RegistryGuid
+$ninjaGuid = Get-NinjaGuid
+
+Write-Host "Current state:"
+Write-Host "  Registry ($RegPath\$RegValueName): $(if ($regGuid) { $regGuid } else { '(empty)' })"
+Write-Host "  NinjaOne ($env:CustomFieldDeviceGuid):           $(if ($ninjaGuid) { $ninjaGuid } else { '(empty)' })"
+Write-Host ""
+
+$exitCode = 0
+
+if ($regGuid -and $ninjaGuid) {
+    if ($regGuid -eq $ninjaGuid) {
+        Write-Host "Device OUID already present and consistent. Nothing to do: $regGuid"
+    } else {
+        # An OUID is assigned once and never changes. Two different values is a
+        # genuine conflict that a human must resolve -- do NOT silently overwrite.
+        Write-Error "CONFLICT: registry ($regGuid) and NinjaOne ($ninjaGuid) hold DIFFERENT device OUIDs. An OUID is assigned once and never changes. Resolve manually -- do not overwrite without confirming which is the established data path."
+        $exitCode = 1
+    }
+} elseif ($regGuid -and -not $ninjaGuid) {
+    Write-Host "Backfilling NinjaOne from on-device registry value..."
+    Set-NinjaGuid -Value $regGuid | Out-Null
+} elseif (-not $regGuid -and $ninjaGuid) {
+    Write-Host "Backfilling on-device registry from NinjaOne value..."
+    Set-RegistryGuid -Value $ninjaGuid
+    Write-Host "  [OK] Registry $RegPath\$RegValueName = $ninjaGuid"
+} else {
+    Write-Host "No device OUID found. Minting a new UUIDv7..."
+    $newGuid = New-UuidV7
+    if ($newGuid -notmatch $GuidRegex) {
+        Write-Error "Generated value '$newGuid' is not a valid UUID. Aborting before persisting."
+        Stop-Transcript
+        exit 1
+    }
+    Write-Host "  Minted: $newGuid"
+    Set-RegistryGuid -Value $newGuid
+    Write-Host "  [OK] Registry $RegPath\$RegValueName = $newGuid"
+    Set-NinjaGuid -Value $newGuid | Out-Null
+}
+
+Write-Host ""
+Write-Host "=== Script complete (exit $exitCode) ==="
+
+Stop-Transcript
+exit $exitCode

--- a/rmm-ninja/tests/lockhart-remediation.Tests.ps1
+++ b/rmm-ninja/tests/lockhart-remediation.Tests.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+  Pester tests for lockhart-remediation.ps1
+.NOTES
+  Repo:    dtc-inc/msp-script-library
+  Path:    rmm-ninja/tests/lockhart-remediation.Tests.ps1
+  Target:  Pester 5+
+  Run:     Invoke-Pester -Path .\rmm-ninja\tests\
+#>
+
+BeforeAll {
+    $script:ScriptPath = (Resolve-Path (Join-Path $PSScriptRoot '..\lockhart-remediation.ps1')).Path
+    if (-not (Test-Path $script:ScriptPath)) { throw "Script under test not found: $script:ScriptPath" }
+    # Fast-run args for child invocations that proceed past the short-circuits
+    $script:FastArgs = @('-SampleSeconds','1','-NetTestTimeoutMs','500','-DnsTimeoutMs','500','-MinUptimeMinutes','0')
+}
+
+Describe 'lockhart-remediation.ps1 - structural' {
+    It 'parses without syntax errors' {
+        $errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:ScriptPath, [ref]$null, [ref]$errors)
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It 'has comment-based help with required sections' {
+        $help = Get-Help $script:ScriptPath -Full -ErrorAction SilentlyContinue
+        $help.Synopsis | Should -Not -BeNullOrEmpty
+        $help.Description | Should -Not -BeNullOrEmpty
+        $help.Parameters.Parameter.Count | Should -BeGreaterThan 0
+    }
+
+    It 'declares all required parameters with safe defaults' {
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:ScriptPath, [ref]$null, [ref]$null)
+        $paramBlock = $ast.ParamBlock
+        $paramBlock | Should -Not -BeNullOrEmpty
+        $mandatory = $paramBlock.Parameters | Where-Object {
+            $_.Attributes.NamedArguments | Where-Object { $_.ArgumentName -eq 'Mandatory' -and $_.Argument.Value -eq $true }
+        }
+        $mandatory | Should -BeNullOrEmpty -Because 'NinjaOne runs unattended; mandatory params would hang the agent'
+    }
+
+    It 'sets ErrorActionPreference = Stop' {
+        $content = Get-Content $script:ScriptPath -Raw
+        $content | Should -Match "\`$ErrorActionPreference\s*=\s*'Stop'"
+    }
+
+    It 'contains the RMM variable declaration block (template section 1)' {
+        $content = Get-Content $script:ScriptPath -Raw
+        $content | Should -Match "## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM"
+    }
+
+    It 'reads RMM checkbox variables via $env: (CLAUDE.md convention)' {
+        $content = Get-Content $script:ScriptPath -Raw
+        $content | Should -Match "Test-RmmFlag 'ForceDisruptiveRepairs'"
+        $content | Should -Match "Test-RmmFlag 'ClearStateAndExit'"
+    }
+}
+
+Describe 'lockhart-remediation.ps1 - HV0 host exclusion (failure-path)' {
+    It 'exits 0 with HypervisorSkip when COMPUTERNAME matches ^HV0' {
+        $originalName = $env:COMPUTERNAME
+        try {
+            $env:COMPUTERNAME = 'HV01-TESTPATTERN'
+            $output = & pwsh -NoProfile -File $script:ScriptPath 2>&1
+            $LASTEXITCODE | Should -Be 0
+            ($output -join "`n") | Should -Match 'HypervisorSkip'
+        } finally {
+            $env:COMPUTERNAME = $originalName
+        }
+    }
+
+    It 'exits 0 with HypervisorSkip when COMPUTERNAME is HV0-{servicetag}' {
+        $originalName = $env:COMPUTERNAME
+        try {
+            $env:COMPUTERNAME = 'HV0-ABC1234'
+            $output = & pwsh -NoProfile -File $script:ScriptPath 2>&1
+            $LASTEXITCODE | Should -Be 0
+            ($output -join "`n") | Should -Match 'HypervisorSkip'
+        } finally {
+            $env:COMPUTERNAME = $originalName
+        }
+    }
+
+    It 'does NOT skip when COMPUTERNAME merely contains HV0 (e.g. SERVER-HV0)' {
+        $originalName = $env:COMPUTERNAME
+        try {
+            $env:COMPUTERNAME = 'SERVER-HV0'
+            $output = & pwsh -NoProfile -File $script:ScriptPath @($script:FastArgs) 2>&1
+            ($output -join "`n") | Should -Not -Match 'HypervisorSkip'
+        } finally {
+            $env:COMPUTERNAME = $originalName
+        }
+    }
+}
+
+Describe 'lockhart-remediation.ps1 - RMM environment variable binding' {
+    It 'honors $env:ClearStateAndExit=1 (NinjaOne checkbox path) without a CLI switch' {
+        $stateFiles = @(
+            'C:\DTC\lockhart_autoremediation.json',
+            'C:\ProgramData\DTC\lockhart_autoremediation.json'
+        )
+        # Back up any real state, then seed sentinels
+        $backups = @{}
+        foreach ($f in $stateFiles) {
+            if (Test-Path $f) { $backups[$f] = Get-Content $f -Raw }
+            $dir = Split-Path $f -Parent
+            if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+            '{"ConsecutiveAttempts":2,"LastResult":"TestSentinel","History":[]}' | Set-Content -Path $f -Force
+        }
+        try {
+            $env:ClearStateAndExit = '1'
+            $output = & pwsh -NoProfile -File $script:ScriptPath 2>&1
+            $LASTEXITCODE | Should -Be 0
+            ($output -join "`n") | Should -Match 'StateCleared'
+        } finally {
+            Remove-Item Env:\ClearStateAndExit -ErrorAction SilentlyContinue
+            foreach ($f in $stateFiles) {
+                if ($backups.ContainsKey($f)) { $backups[$f] | Set-Content -Path $f -Force }
+                else { Remove-Item $f -Force -ErrorAction SilentlyContinue }
+            }
+        }
+    }
+}
+
+Describe 'lockhart-remediation.ps1 - happy-path (NotApplicable on host without Lockhart)' {
+    It 'exits 0 with NotApplicable when Lockhart service does not exist' {
+        $lockhartInstalled = $null -ne (Get-CimInstance Win32_Service -Filter "Name='Lockhart'" -ErrorAction SilentlyContinue)
+        if ($lockhartInstalled) {
+            Set-ItResult -Skipped -Because 'Lockhart is installed on this test host; cannot validate NotApplicable path here'
+        }
+        $output = & pwsh -NoProfile -File $script:ScriptPath @($script:FastArgs) 2>&1
+        $LASTEXITCODE | Should -Be 0
+        ($output -join "`n") | Should -Match 'NotApplicable'
+    }
+}


### PR DESCRIPTION
## Summary

Brings Veeam B2 provisioning in line with the DTC [Cloud Backup Architecture Standards](https://kb.dtctoday.com/books/dtcs-pillars-of-technology/page/cloud-backup-architecture-standards) and [OUID Standard](https://kb.dtctoday.com/books/dtcs-pillars-of-technology/page/operational-uuid-ouid-standard), pushes storage isolation down to the location layer, and adds the missing device-identity primitive.

**Storage scheme**
```
bucket:  veeam-{location-ouid-flat}     (one bucket per location)
folder:  {device-ouid-dashed}/          (one repo root per BDR; Veeam owns below)
```
Locations get bought and sold, so the bucket tracks the location OUID (looked up at runtime from NinjaOne) rather than the org. The per-device folder uses the BDR device OUID, which is **recomputable from a stable source** (minted once, persisted on the device) so re-runs and rebuilds resolve to the same folder and reclaim existing data instead of orphaning it. This is why neither Veeam's internal instance GUID nor a creation timestamp was used (both regenerate on rebuild).

## Changes

**`bdr-veeam/veeam-configure-backblaze-repo.ps1`**
- Bucket `veeam-{location-ouid-flat}` from the NinjaOne location field (replaces org UUID + time-based short id).
- Folder = device OUID, read from registry `HKLM\SOFTWARE\DTC\DeviceGuid` then the NinjaOne `Device GUID` field. Fails fast pointing at the minting script if absent.

**`rmm-ninja/ninja-ensure-device-guid.ps1`** (new)
- Boot-time, idempotent, self-healing. Mints a canonical UUIDv7 device OUID once and persists it to registry + NinjaOne. Exits early if already consistent; backfills a half-provisioned state; refuses to overwrite a conflicting assigned OUID. Native `[Guid]::CreateVersion7()` with a dependency-free UUIDv7 fallback for older runtimes.

**`bdr-veeam/veeam-inventory.ps1`**
- Splits the S3 inventory into **Active** vs **Inactive** repositories (active = a backup copy job targets it), each with a Last Backup column.
- New `CUSTOM_FIELD_S3_TOTAL_SIZE` totals used space across all S3 repos so leftover (pre-move) buckets surface in the cost picture.

## New NinjaOne fields to create
- `CUSTOM_FIELD_LOCATION_UUID` - Location text field (location OUID)
- `CUSTOM_FIELD_DEVICE_GUID` - Device text field (device OUID; written by the minting script)
- `CUSTOM_FIELD_S3_TOTAL_SIZE` - Device text field (total S3 size)

## Testing
- PowerShell parser clean on all three scripts.
- UUIDv7 generator verified RFC 9562-correct: version nibble `7`, variant in `{8,9,a,b}`, embedded timestamp decodes to creation time, time-ordered.
- Inventory total + active/inactive split exercised with synthetic repo data.
- **Not yet run on a live BDR** - Veeam cmdlet paths and `Ninja-Property-Get/Set` need a real-device smoke test. Bucket/folder naming is deterministic so a dry run is safe.

## RMM compatibility
Dual-mode (interactive + RMM) preserved. Minting script requires SYSTEM context (HKLM write + Ninja cmdlets); intended as a boot trigger in NinjaOne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
