### PR TITLE
Fix BitLocker suspend RMM hang ($env:RMM convention)

### DIFF
--- a/msft-windows/msft-windows-suspend-bitlocker.ps1
+++ b/msft-windows/msft-windows-suspend-bitlocker.ps1
@@ -1,26 +1,23 @@
-param(
-    # Number of reboots BitLocker stays suspended for before it auto-resumes.
-    # Resolution order: -RebootCount parameter > $env:RebootCount > default 1.
-    # 1 = suspend for exactly the next reboot, then BitLocker re-protects itself.
-    [int]$RebootCount = 0
-)
-
-# Getting input from user if not running from RMM else set variables from RMM.
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $env:RMM         - "1" when executed from the RMM (string). Anything else = interactive.
+## $env:Description - ticket # and/or initials, used as the job description
+## $env:RebootCount - reboots BitLocker stays suspended before it auto-resumes (optional, default 1)
 
 $ScriptLogName = "bitlocker-suspend.log"
 
-# Resolve RebootCount: parameter wins; else environment variable; else default 1.
-if ($RebootCount -le 0 -and $env:RebootCount) {
-    [int]::TryParse($env:RebootCount, [ref]$RebootCount) | Out-Null
+# Resolve RebootCount from the RMM environment variable; default to 1 if unset/invalid.
+# 1 = suspend for exactly the next reboot, then BitLocker re-protects itself.
+$RebootCount = 1
+$parsedCount = 0
+if ($env:RebootCount -and [int]::TryParse($env:RebootCount, [ref]$parsedCount) -and $parsedCount -ge 1) {
+    $RebootCount = $parsedCount
 }
-if ($RebootCount -le 0) { $RebootCount = 1 }
 
-if ($RMM -ne 1) {
+if ($env:RMM -ne "1") {
+    # Interactive run: prompt for a description.
     $ValidInput = 0
-    # Checking for valid input.
     while ($ValidInput -ne 1) {
-        # Ask for input here. This is the interactive area for getting variable information.
-        # Remember to make ValidInput = 1 whenever correct input is given.
         $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
         if ($Description) {
             $ValidInput = 1
@@ -28,67 +25,60 @@ if ($RMM -ne 1) {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
 
 } else {
-    # Store the logs in the RMMScriptPath
-    if ($null -ne $RMMScriptPath) {
-        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
-
+    # RMM run: all variables arrive as environment variables.
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
-
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
     }
 
-    if ($null -eq $Description) {
+    $Description = $env:Description
+    if ([string]::IsNullOrEmpty($Description)) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
         $Description = "No Description"
     }
-
-
 }
 
 Start-Transcript -Path $LogPath
 
 Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
-Write-Host "RMM: $RMM"
+Write-Host "RMM: $env:RMM"
 Write-Host "RebootCount: $RebootCount"
 
-# Function to suspend BitLocker on the system volume for $RebootCount reboot(s).
-# Only the OS/system volume can trigger the pre-boot recovery prompt; fixed data
-# volumes auto-unlock once Windows is up off the (suspended-but-bootable) system
-# drive, so suspending $env:SystemDrive is sufficient to cover the reboot.
+# Suspend BitLocker on the system volume only. Only the OS/system volume can throw
+# the pre-boot recovery prompt; fixed data volumes auto-unlock from the
+# (suspended-but-bootable) system drive once Windows is up, so this covers the reboot.
 function Suspend-SystemBitLocker {
     param([int]$RebootCount = 1)
+    $mp = $env:SystemDrive
     try {
-        $mp = $env:SystemDrive
         $vol = Get-BitLockerVolume -MountPoint $mp -ErrorAction Stop
-
-        if ($vol.ProtectionStatus -eq 'On') {
-            Suspend-BitLocker -MountPoint $mp -RebootCount $RebootCount -Verbose | Out-Null
-
-            # Verify protection is actually off before we rely on it.
-            $vol = Get-BitLockerVolume -MountPoint $mp
-            if ($vol.ProtectionStatus -eq 'On') {
-                Write-Error "System volume $mp still protected after suspend."
-                exit 1
-            }
-            Write-Output "BitLocker on system volume $mp suspended for $RebootCount reboot(s)."
-        } else {
+        if ($vol.ProtectionStatus -ne 'On') {
             Write-Output "System volume $mp is not actively protected; nothing to suspend."
+            return 0
         }
-        Exit 0
+        Suspend-BitLocker -MountPoint $mp -RebootCount $RebootCount -Verbose | Out-Null
+
+        # Verify protection is actually off before we rely on it.
+        $vol = Get-BitLockerVolume -MountPoint $mp
+        if ($vol.ProtectionStatus -eq 'On') {
+            Write-Error "System volume $mp still protected after suspend."
+            return 1
+        }
+        Write-Output "BitLocker on system volume $mp suspended for $RebootCount reboot(s)."
+        return 0
     }
     catch {
         Write-Error "An error occurred: $_"
-        exit 1
+        return 1
     }
 }
 
-# Call the function to suspend BitLocker on the system volume
-Suspend-SystemBitLocker -RebootCount $RebootCount
-
-
+$exitCode = Suspend-SystemBitLocker -RebootCount $RebootCount
 
 Stop-Transcript
+exit $exitCode


### PR DESCRIPTION
The version currently on `development` still reads **bare `$RMM`** and uses a top-level `param()` block, so it **hangs** when run from NinjaOne — per this repo's conventions NinjaRMM passes preset variables as **environment variables**, making bare `$RMM` `$null` in RMM mode, which drops the script into the interactive `Read-Host` with no console to answer it.

## Fix
- Detect context via `$env:RMM -ne "1"` (string compare).
- Read `RebootCount` / `Description` / `RMMScriptPath` from `$env:`; **remove the `param()` block** that broke RMM variable injection.
- Keep the system-volume-only suspend (`$env:SystemDrive`, `-RebootCount` default 1) with post-suspend verification and a single clean `Stop-Transcript` + exit-code path.

In NinjaOne set preset variables `RMM=1` (required to run non-interactive) and optionally `RebootCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)