### PR TITLE
fix(checkpoint-aging): bitness-safe Hyper-V detection (fixes ThreadStartException)

### DIFF
--- a/msft-windows/msft-windows-checkpoint-aging.ps1
+++ b/msft-windows/msft-windows-checkpoint-aging.ps1
@@ -1,62 +1,95 @@
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## $env:RMM         - Set to "1" when running from the RMM. Anything else is treated as interactive.
+## $env:Description - Ticket # and/or technician initials. Used as the job Description for audit trail.
+## $env:DaysAging   - Number of days old a checkpoint must be to flag it. Negative or positive both work
+##                    (e.g. "-7" or "7" both mean "older than 7 days").
+
 # Getting input from user if not running from RMM else set variables from RMM.
 
 $ScriptLogName = "windows-hyper-v-checkpoint-aging.log"
 
-if ($RMM -ne 1) {
+# NinjaRMM passes preset variables as environment variables. Older deployments of this
+# script injected them as bare PowerShell variables. Coalesce bare -> env so the script
+# works regardless of how the RMM supplies them, then reference $env: consistently below.
+if ([string]::IsNullOrEmpty($env:RMM)         -and $RMM)         { $env:RMM = $RMM }
+if ([string]::IsNullOrEmpty($env:Description) -and $Description) { $env:Description = $Description }
+if ([string]::IsNullOrEmpty($env:DaysAging)   -and $DaysAging)   { $env:DaysAging = $DaysAging }
+
+if ($env:RMM -ne "1") {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {
         # Ask for input here. This is the interactive area for getting variable information.
         # Remember to make ValidInput = 1 whenever correct input is given.
-        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
-        $DaysAging = Read-Host "Please enter the amount of days to consider a Hyper-V"
-        if ($Description) {
+        $env:Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        $env:DaysAging = Read-Host "Please enter the number of days old a Hyper-V checkpoint must be to flag it (e.g. 7)"
+        if ($env:Description -and ($env:DaysAging -as [int])) {
             $ValidInput = 1
         } else {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
 
-} else { 
-    # Store the logs in the RMMScriptPath
-    if ($null -eq $RMMScriptPath) {
-        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
-        
+} else {
+    # Store the logs in the RMMScriptPath if available, otherwise fall back to the Windows logs dir.
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
-        
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
     }
 
-    if ($null -eq $Description) {
+    if ([string]::IsNullOrEmpty($env:Description)) {
         Write-Output "Description is null. This was most likely run automatically from the RMM and no information was passed."
-        $Description = "No Description"
-    }   
-
-
-    
+        $env:Description = "No Description"
+    }
 }
+
+# Normalize DaysAging to a negative integer so AddDays() walks backwards from now.
+# Accepts "7", "-7", or empty (defaults to 1 day).
+$daysAgingInt = $env:DaysAging -as [int]
+if ($null -eq $daysAgingInt) { $daysAgingInt = 1 }
+$daysAgingInt = -[math]::Abs($daysAgingInt)
 
 Start-Transcript -Path $LogPath
 
-Write-Output "Description: $Description"
+Write-Output "Description: $env:Description"
 Write-Output "Log path: $LogPath"
-Write-Output "RMM: $RMM"
-Write-Output "Days Aging: $DaysAging"
+Write-Output "RMM: $env:RMM"
+Write-Output "Days Aging: $daysAgingInt"
 
-if (-not (Get-WindowsFeature -Name Hyper-V)) {
-    Write-Output "Hyper-V role/feature is not installed."
+# Detect Hyper-V WITHOUT the ServerManager module / Get-WindowsFeature.
+#
+# Get-WindowsFeature lives in the ServerManager module, which is Server-only and is NOT
+# supported in the 32-bit PowerShell host that NinjaRMM uses to run scripts -- calling it
+# there throws "Thread failed to start" (System.Threading.ThreadStartException).
+#
+# The Hyper-V Virtual Machine Management service (vmms) and the Get-VM cmdlet are present
+# only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
+$vmmsService = Get-Service -Name "vmms" -ErrorAction SilentlyContinue
+if (-not $vmmsService) {
+    Write-Output "Hyper-V is not installed on this machine (vmms service not found)."
+    Stop-Transcript
     Exit 0
 }
 
-$AgingCheckpoints = Get-VM | Get-VMSnapshot | Where {$_.CreationTime -lt (Get-Date).AddDays($DaysAging)}
+if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
+    Write-Output "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot enumerate checkpoints."
+    Stop-Transcript
+    Exit 0
+}
 
-if ($AgingCheckpoints) { 
-    $AgingCheckpoints | ForEach-Object { Write-Output "Checkpoint $($_.Name) is older than 1 day. Checkpoint created on $($_.CreationTime). Please delete this checkpoint."}
+$cutoff = (Get-Date).AddDays($daysAgingInt)
+$AgingCheckpoints = Get-VM | Get-VMSnapshot | Where-Object { $_.CreationTime -lt $cutoff }
+
+if ($AgingCheckpoints) {
+    $AgingCheckpoints | ForEach-Object {
+        Write-Output "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $([math]::Abs($daysAgingInt)) day(s). Created on $($_.CreationTime). Please delete this checkpoint."
+    }
+    Stop-Transcript
     Exit 1
 } else {
-    Write-Output "There are no checkpoints older than 1 day that need to be deleted."
+    Write-Output "There are no checkpoints older than $([math]::Abs($daysAgingInt)) day(s) that need to be deleted."
+    Stop-Transcript
     Exit 0
 }
-
-Stop-Transcript


### PR DESCRIPTION
## Problem

The Hyper-V checkpoint-aging script crashes under NinjaRMM with:

```
Thread failed to start.
System.Threading.ThreadStartException
```

It dies immediately after logging its variables, at the Hyper-V detection line.

## Root cause

NinjaRMM runs custom scripts in **32-bit (x86) PowerShell**. The detection used `Get-WindowsFeature`, which comes from the Server-only `ServerManager` module. That module is **not supported in a 32-bit host on a 64-bit OS** — invoking it throws `System.Threading.ThreadStartException` ("Thread failed to start"). On client OSes the cmdlet doesn't exist at all.

## Fix

Detect Hyper-V via the **`vmms` service** plus the **`Get-VM`** cmdlet — both exist only when Hyper-V is installed and both are bitness-safe on client and server.

Same change also fixes three latent issues in the script:

- **Detection was always-false** — `-not (Get-WindowsFeature -Name Hyper-V)` never tripped because the cmdlet returns a feature object regardless of install state.
- **`Stop-Transcript` was unreachable** — it sat after the `Exit` calls; every exit path now closes the transcript first.
- **`$env:` alignment** — variable handling now follows the repo standard (`$env:` with a bare→env coalesce so it works whichever way the RMM injects), compares `$env:RMM` against `"1"`, and normalizes `DaysAging` via `-[math]::Abs()` so `7` and `-7` both mean "older than 7 days." Messages now report the real threshold and VM name instead of the hardcoded "older than 1 day."

## Behavior contract (unchanged)

- **Exit 1** when aging checkpoints are found (RMM condition alerts)
- **Exit 0** when clean or Hyper-V isn't present

## Testing

- `[Parser]::ParseFile` — no syntax errors.
- Logic traced for RMM + interactive paths and for present/absent Hyper-V.
- Not yet executed on a live Hyper-V host under the 32-bit NinjaRMM runner — recommend a validation run there before wide rollout.

## Note

The sibling `hyper-v-delete-all-checkpoints.ps1` has the **same `Get-WindowsFeature` bug** (plus an unrelated bulk-delete bug). Not touched here — can follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)