### PR TITLE
fix(delete-all-checkpoints): bitness-safe Hyper-V detection + correct per-checkpoint delete

### DIFF
--- a/msft-windows/hyper-v-delete-all-checkpoints.ps1
+++ b/msft-windows/hyper-v-delete-all-checkpoints.ps1
@@ -6,9 +6,21 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     Exit 1
 }
 
-# Check if Hyper-V feature is installed
-if (-not (Get-WindowsFeature -Name Hyper-V | Where-Object { $_.Installed })) {
-    Write-Host "Hyper-V feature is not installed on this machine." -ForegroundColor Red
+# Detect Hyper-V WITHOUT the ServerManager module / Get-WindowsFeature.
+#
+# Get-WindowsFeature lives in the ServerManager module, which is Server-only and is NOT
+# supported in the 32-bit PowerShell host that RMMs (e.g. NinjaRMM) use to run scripts --
+# calling it there throws "Thread failed to start" (System.Threading.ThreadStartException).
+#
+# The Hyper-V Virtual Machine Management service (vmms) and the Get-VM cmdlet are present
+# only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
+if (-not (Get-Service -Name "vmms" -ErrorAction SilentlyContinue)) {
+    Write-Host "Hyper-V is not installed on this machine (vmms service not found)." -ForegroundColor Red
+    Exit 1
+}
+
+if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
+    Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot manage checkpoints." -ForegroundColor Red
     Exit 1
 }
 
@@ -26,14 +38,16 @@ foreach ($vm in $vmList) {
         Write-Host "No checkpoints found for VM $($vm.Name)." -ForegroundColor Yellow
     } else {
         foreach ($checkpoint in $checkpointList) {
-            try { 
-                Write-Host "Deleting checkpoint $checkpoint for $vm"
-                $vmList| Remove-VMSnapshot
-
+            try {
+                Write-Host "Deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)'."
+                # Remove only THIS checkpoint. The previous version piped $vmList into
+                # Remove-VMSnapshot, which removed every snapshot on every VM on each loop
+                # iteration.
+                $checkpoint | Remove-VMSnapshot
             } catch {
-                Write-Host "Error deleting checkpoint $checkpiont for $vm."
-                Exit 1
-            
+                Write-Host "Error deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)': $_" -ForegroundColor Red
+                # Keep going so one failure does not abort the rest of the cleanup.
+                continue
             }
         }
     }


### PR DESCRIPTION
## Problem

`hyper-v-delete-all-checkpoints.ps1` shared the same Hyper-V-detection defect as the checkpoint-aging script (fixed in #93), plus a destructive delete bug.

## Fixes

1. **ThreadStartException** — replaced `Get-WindowsFeature` (Server-only `ServerManager` module, unsupported in the 32-bit PowerShell host RMMs use → "Thread failed to start") with a bitness-safe check of the `vmms` service and the `Get-VM` cmdlet.

2. **Destructive bulk-delete bug** — the inner loop ran `$vmList | Remove-VMSnapshot`, piping **every VM** into `Remove-VMSnapshot` on each iteration. That removed all snapshots on all VMs rather than the single checkpoint being iterated. Now removes only the current checkpoint via `$checkpoint | Remove-VMSnapshot`. (Net effect on a full run was the same — delete everything — but the per-iteration behavior was wrong and would misbehave if narrowed.)

3. **Minor** — fixed the `$checkpiont` typo in the error message; the `catch` now `continue`s to the next checkpoint instead of `Exit 1` aborting the whole run on the first failure.

## Testing

- `[Parser]::ParseFile` — no syntax errors.
- Not executed against a live Hyper-V host — recommend a validation run before use.

## Note

This is an interactive admin tool (no RMM/transcript scaffolding). I kept it that way and limited this PR to the bug fixes; adding dual-mode + logging would be a separate `improvement/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)