### PR TITLE
refactor(hyper-v-checkpoints): conform both checkpoint scripts to the DTC template

### DIFF
--- a/msft-windows/hyper-v-delete-all-checkpoints.ps1
+++ b/msft-windows/hyper-v-delete-all-checkpoints.ps1
@@ -1,54 +1,132 @@
-# This was written by ChatGPT and modified by Nate Smith (nettts)
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM           - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description   - Ticket # or initials for audit trail
+## $env:RMMScriptPath - Optional log directory base provided by the RMM
+##
+## WARNING: This script DELETES every Hyper-V checkpoint on every VM on the host. It is a
+## deliberate maintenance action -- deploy it intentionally.
 
-# Check if the script is running with administrator privileges
+# Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
+
+$ScriptLogName = "windows-hyper-v-delete-all-checkpoints.log"
+
+# --- Input handling: RMM vs interactive ----------------------------------
+
+if ($env:RMM -ne "1") {
+    $ValidInput = 0
+    # Checking for valid input.
+    while ($ValidInput -ne 1) {
+        # Ask for input here. This is the interactive area for getting variable information.
+        # Remember to make ValidInput = 1 whenever correct input is given.
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
+            $ValidInput = 1
+        } else {
+            Write-Host "Invalid input. Please try again."
+        }
+    }
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    # RMM mode: store logs under $env:RMMScriptPath if the RMM provided one,
+    # otherwise fall back to the standard Windows logs directory.
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+
+    if ([string]::IsNullOrEmpty($env:Description)) {
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        $env:Description = "No Description"
+    }
+}
+
+# This script needs administrator rights to manage Hyper-V and to write to the system log
+# directory. Check before starting the transcript (a non-admin run can't write the log anyway).
 if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Host "Please run this script with administrator privileges." -ForegroundColor Red
     Exit 1
 }
 
+# Ensure log directory exists before starting the transcript
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    Write-Host "Creating log directory: $logDir"
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# --- Script logic --------------------------------------------------------
+
+Start-Transcript -Path $LogPath
+
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+
 # Detect Hyper-V WITHOUT the ServerManager module / Get-WindowsFeature.
 #
 # Get-WindowsFeature lives in the ServerManager module, which is Server-only and is NOT
-# supported in the 32-bit PowerShell host that RMMs (e.g. NinjaRMM) use to run scripts --
-# calling it there throws "Thread failed to start" (System.Threading.ThreadStartException).
+# supported in the 32-bit PowerShell host that RMMs use to run scripts -- calling it there
+# throws "Thread failed to start" (System.Threading.ThreadStartException).
 #
 # The Hyper-V Virtual Machine Management service (vmms) and the Get-VM cmdlet are present
 # only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
 if (-not (Get-Service -Name "vmms" -ErrorAction SilentlyContinue)) {
-    Write-Host "Hyper-V is not installed on this machine (vmms service not found)." -ForegroundColor Red
-    Exit 1
+    Write-Host "Hyper-V is not installed on this machine (vmms service not found)."
+    Stop-Transcript
+    Exit 0
 }
 
 if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
-    Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot manage checkpoints." -ForegroundColor Red
-    Exit 1
+    Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot manage checkpoints."
+    Stop-Transcript
+    Exit 0
 }
 
-# Delete all Hyper-V snapshots
-$vmList = Get-VM
+# Delete all Hyper-V checkpoints, one VM at a time.
+try {
+    $vmList = Get-VM -ErrorAction Stop
+} catch {
+    Write-Host "ERROR: Failed to enumerate Hyper-V VMs: $_" -ForegroundColor Red
+    Stop-Transcript
+    Exit 2
+}
 
-if ($vmList.Count -eq 0) {
+if (-not $vmList) {
     Write-Host "No virtual machines found on this host." -ForegroundColor Yellow
-    return
+    Stop-Transcript
+    Exit 0
 }
 
+$failureCount = 0
 foreach ($vm in $vmList) {
     $checkpointList = Get-VMSnapshot -VMName $vm.Name
-    if ($checkpointList.Count -eq 0) {
-        Write-Host "No checkpoints found for VM $($vm.Name)." -ForegroundColor Yellow
+    if (-not $checkpointList) {
+        Write-Host "No checkpoints found for VM '$($vm.Name)'." -ForegroundColor Yellow
     } else {
         foreach ($checkpoint in $checkpointList) {
             try {
                 Write-Host "Deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)'."
-                # Remove only THIS checkpoint. The previous version piped $vmList into
-                # Remove-VMSnapshot, which removed every snapshot on every VM on each loop
-                # iteration.
+                # Remove only THIS checkpoint. An earlier version piped $vmList into
+                # Remove-VMSnapshot, which removed every snapshot on every VM each iteration.
                 $checkpoint | Remove-VMSnapshot
             } catch {
                 Write-Host "Error deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)': $_" -ForegroundColor Red
+                $failureCount++
                 # Keep going so one failure does not abort the rest of the cleanup.
                 continue
             }
         }
     }
 }
+
+if ($failureCount -gt 0) {
+    Write-Host "Completed with $failureCount checkpoint deletion failure(s). See log for details." -ForegroundColor Red
+    Stop-Transcript
+    Exit 1
+}
+
+Write-Host "All checkpoints processed successfully."
+Stop-Transcript
+Exit 0

--- a/msft-windows/msft-windows-checkpoint-aging.ps1
+++ b/msft-windows/msft-windows-checkpoint-aging.ps1
@@ -1,19 +1,21 @@
 ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
-## $env:RMM         - Set to "1" when running from the RMM. Anything else is treated as interactive.
-## $env:Description - Ticket # and/or technician initials. Used as the job Description for audit trail.
-## $env:DaysAging   - Number of days old a checkpoint must be to flag it. Negative or positive both work
-##                    (e.g. "-7" or "7" both mean "older than 7 days").
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM           - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description   - Ticket # or initials for audit trail
+## $env:RMMScriptPath - Optional log directory base provided by the RMM
+## $env:DaysAging     - Number of days old a checkpoint must be to flag it (default: "7").
+##                      Positive or negative both work (e.g. "7" or "-7" both mean "older than 7 days").
 
-# Getting input from user if not running from RMM else set variables from RMM.
+# Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
 
 $ScriptLogName = "windows-hyper-v-checkpoint-aging.log"
 
-# NinjaRMM passes preset variables as environment variables. Older deployments of this
-# script injected them as bare PowerShell variables. Coalesce bare -> env so the script
-# works regardless of how the RMM supplies them, then reference $env: consistently below.
-if ([string]::IsNullOrEmpty($env:RMM)         -and $RMM)         { $env:RMM = $RMM }
-if ([string]::IsNullOrEmpty($env:Description) -and $Description) { $env:Description = $Description }
-if ([string]::IsNullOrEmpty($env:DaysAging)   -and $DaysAging)   { $env:DaysAging = $DaysAging }
+# --- Default optional RMM environment variables --------------------------
+if ([string]::IsNullOrEmpty($env:DaysAging)) {
+    $env:DaysAging = "7"
+}
+
+# --- Input handling: RMM vs interactive ----------------------------------
 
 if ($env:RMM -ne "1") {
     $ValidInput = 0
@@ -21,18 +23,18 @@ if ($env:RMM -ne "1") {
     while ($ValidInput -ne 1) {
         # Ask for input here. This is the interactive area for getting variable information.
         # Remember to make ValidInput = 1 whenever correct input is given.
-        $env:Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
         $env:DaysAging = Read-Host "Please enter the number of days old a Hyper-V checkpoint must be to flag it (e.g. 7)"
-        if ($env:Description -and ($env:DaysAging -as [int])) {
+        if ($env:Description -and ($null -ne ($env:DaysAging -as [int]))) {
             $ValidInput = 1
         } else {
             Write-Host "Invalid input. Please try again."
         }
     }
     $LogPath = "$env:WINDIR\logs\$ScriptLogName"
-
 } else {
-    # Store the logs in the RMMScriptPath if available, otherwise fall back to the Windows logs dir.
+    # RMM mode: store logs under $env:RMMScriptPath if the RMM provided one,
+    # otherwise fall back to the standard Windows logs directory.
     if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
         $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
@@ -40,23 +42,31 @@ if ($env:RMM -ne "1") {
     }
 
     if ([string]::IsNullOrEmpty($env:Description)) {
-        Write-Output "Description is null. This was most likely run automatically from the RMM and no information was passed."
+        Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
         $env:Description = "No Description"
     }
 }
 
+# Ensure log directory exists before starting the transcript
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    Write-Host "Creating log directory: $logDir"
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
 # Normalize DaysAging to a negative integer so AddDays() walks backwards from now.
-# Accepts "7", "-7", or empty (defaults to 1 day).
 $daysAgingInt = $env:DaysAging -as [int]
-if ($null -eq $daysAgingInt) { $daysAgingInt = 1 }
+if ($null -eq $daysAgingInt) { $daysAgingInt = 7 }
 $daysAgingInt = -[math]::Abs($daysAgingInt)
+
+# --- Script logic --------------------------------------------------------
 
 Start-Transcript -Path $LogPath
 
-Write-Output "Description: $env:Description"
-Write-Output "Log path: $LogPath"
-Write-Output "RMM: $env:RMM"
-Write-Output "Days Aging: $daysAgingInt"
+Write-Host "Description: $env:Description"
+Write-Host "Log path: $LogPath"
+Write-Host "RMM: $env:RMM"
+Write-Host "Days Aging: $daysAgingInt"
 
 # Detect Hyper-V WITHOUT the ServerManager module / Get-WindowsFeature.
 #
@@ -66,30 +76,39 @@ Write-Output "Days Aging: $daysAgingInt"
 #
 # The Hyper-V Virtual Machine Management service (vmms) and the Get-VM cmdlet are present
 # only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
-$vmmsService = Get-Service -Name "vmms" -ErrorAction SilentlyContinue
-if (-not $vmmsService) {
-    Write-Output "Hyper-V is not installed on this machine (vmms service not found)."
+if (-not (Get-Service -Name "vmms" -ErrorAction SilentlyContinue)) {
+    Write-Host "Hyper-V is not installed on this machine (vmms service not found)."
     Stop-Transcript
     Exit 0
 }
 
 if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
-    Write-Output "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot enumerate checkpoints."
+    Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot enumerate checkpoints."
     Stop-Transcript
     Exit 0
 }
 
 $cutoff = (Get-Date).AddDays($daysAgingInt)
-$AgingCheckpoints = Get-VM | Get-VMSnapshot | Where-Object { $_.CreationTime -lt $cutoff }
+
+# Enumerate checkpoints. If this throws (e.g. insufficient privilege, WMI/vmms fault) we must
+# NOT fall through and report "no aging checkpoints" -- that would be a false all-clear that
+# masks a broken host. Surface it with a distinct exit code instead.
+try {
+    $AgingCheckpoints = Get-VM -ErrorAction Stop | Get-VMSnapshot -ErrorAction Stop | Where-Object { $_.CreationTime -lt $cutoff }
+} catch {
+    Write-Host "ERROR: Failed to enumerate Hyper-V VMs/checkpoints: $_"
+    Stop-Transcript
+    Exit 2
+}
 
 if ($AgingCheckpoints) {
     $AgingCheckpoints | ForEach-Object {
-        Write-Output "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $([math]::Abs($daysAgingInt)) day(s). Created on $($_.CreationTime). Please delete this checkpoint."
+        Write-Host "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $([math]::Abs($daysAgingInt)) day(s). Created on $($_.CreationTime). Please delete this checkpoint."
     }
     Stop-Transcript
     Exit 1
 } else {
-    Write-Output "There are no checkpoints older than $([math]::Abs($daysAgingInt)) day(s) that need to be deleted."
+    Write-Host "There are no checkpoints older than $([math]::Abs($daysAgingInt)) day(s) that need to be deleted."
     Stop-Transcript
     Exit 0
 }


### PR DESCRIPTION
Brings both Hyper-V checkpoint scripts in line with `script-template-powershell.ps1` (the three-part RMM structure). Follow-up to #93 and #94, which fixed the crash; this makes the scripts structurally standard.

## `msft-windows-checkpoint-aging.ps1`
- Standard RMM variable-declaration header.
- **Dropped the non-standard bare→`$env:` coalesce** — reads inputs via `$env:` only, per the template.
- `DaysAging` default (`"7"`) set in the optional-vars block at the top.
- Added the **log-directory creation** step before `Start-Transcript`.
- **Guarded VM/checkpoint enumeration in try/catch.** A live test surfaced that a runtime `Get-VM` failure (insufficient privilege, WMI/vmms fault) was being swallowed and reported as "no aging checkpoints" / exit 0 — a false all-clear that masks a broken host. It now exits **2** with a clear message.

## `hyper-v-delete-all-checkpoints.ps1`
- Added the **entire three-part structure it was missing**: RMM vs interactive input handling, `Description` audit capture, log-dir creation, `Start`/`Stop-Transcript` framing.
- Kept the admin check (moved ahead of the transcript) and the bitness-safe `vmms`/`Get-VM` detection.
- Guarded `Get-VM` enumeration (exit 2 on failure); tracks per-checkpoint delete failures and exits 1 if any occurred.

## Exit codes (both)
| Code | Meaning |
|---|---|
| 0 | clean / healthy |
| 1 | actionable — aging checkpoints found / delete failures occurred |
| 2 | enumeration error (couldn't query Hyper-V) |

## Testing
- `[Parser]::ParseFile` — both clean.
- Ran `msft-windows-checkpoint-aging.ps1` in simulated RMM mode on a Hyper-V host. Confirmed: standard input handling, log-dir creation, transcript, `DaysAging` normalization (`7` → `-7`), and the new error path (non-admin `Get-VM` failure → exit 2 instead of false exit 0).
- Delete script not run against live VMs (destructive) — logic traced only.

## Note
`hyper-v-delete-all-checkpoints.ps1` keeps its filename (no `msft-windows-` prefix) to avoid breaking any existing RMM script mapping. Can rename for naming consistency in a separate change if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)