### PR TITLE
improvement(hyper-v-checkpoints): harden checkpoint enumeration & deletion

### DIFF
--- a/msft-windows/hyper-v-delete-all-checkpoints.ps1
+++ b/msft-windows/hyper-v-delete-all-checkpoints.ps1
@@ -99,27 +99,43 @@ if (-not $vmList) {
     Exit 0
 }
 
+$deletedCount = 0
 $failureCount = 0
 foreach ($vm in $vmList) {
-    $checkpointList = Get-VMSnapshot -VMName $vm.Name
+    # Enumerate this VM's checkpoints. A failure here (e.g. WMI/vmms fault) must not abort the
+    # whole run -- record it and move on to the next VM.
+    try {
+        $checkpointList = Get-VMSnapshot -VMName $vm.Name -ErrorAction Stop
+    } catch {
+        Write-Host "Error reading checkpoints for VM '$($vm.Name)': $_" -ForegroundColor Red
+        $failureCount++
+        continue
+    }
+
     if (-not $checkpointList) {
         Write-Host "No checkpoints found for VM '$($vm.Name)'." -ForegroundColor Yellow
-    } else {
-        foreach ($checkpoint in $checkpointList) {
-            try {
-                Write-Host "Deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)'."
-                # Remove only THIS checkpoint. An earlier version piped $vmList into
-                # Remove-VMSnapshot, which removed every snapshot on every VM each iteration.
-                $checkpoint | Remove-VMSnapshot
-            } catch {
-                Write-Host "Error deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)': $_" -ForegroundColor Red
-                $failureCount++
-                # Keep going so one failure does not abort the rest of the cleanup.
-                continue
-            }
+        continue
+    }
+
+    foreach ($checkpoint in $checkpointList) {
+        try {
+            Write-Host "Deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)'."
+            # Remove only THIS checkpoint. An earlier version piped $vmList into
+            # Remove-VMSnapshot, which removed every snapshot on every VM each iteration.
+            # -Confirm:$false guarantees no prompt under any $ConfirmPreference (RMM runs non-interactive).
+            $checkpoint | Remove-VMSnapshot -Confirm:$false -ErrorAction Stop
+            $deletedCount++
+        } catch {
+            Write-Host "Error deleting checkpoint '$($checkpoint.Name)' for VM '$($vm.Name)': $_" -ForegroundColor Red
+            $failureCount++
+            # Keep going so one failure does not abort the rest of the cleanup.
+            continue
         }
     }
 }
+
+Write-Host "Summary: $deletedCount checkpoint(s) deleted, $failureCount failure(s)."
+Write-Host "Note: deleting a checkpoint triggers an AVHDX merge that completes asynchronously after this script exits."
 
 if ($failureCount -gt 0) {
     Write-Host "Completed with $failureCount checkpoint deletion failure(s). See log for details." -ForegroundColor Red

--- a/msft-windows/msft-windows-checkpoint-aging.ps1
+++ b/msft-windows/msft-windows-checkpoint-aging.ps1
@@ -9,10 +9,11 @@
 # Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
 
 $ScriptLogName = "windows-hyper-v-checkpoint-aging.log"
+$DefaultDaysAging = 7
 
 # --- Default optional RMM environment variables --------------------------
 if ([string]::IsNullOrEmpty($env:DaysAging)) {
-    $env:DaysAging = "7"
+    $env:DaysAging = "$DefaultDaysAging"
 }
 
 # --- Input handling: RMM vs interactive ----------------------------------
@@ -54,10 +55,16 @@ if (-not (Test-Path -Path $logDir)) {
     New-Item -Path $logDir -ItemType Directory -Force | Out-Null
 }
 
-# Normalize DaysAging to a negative integer so AddDays() walks backwards from now.
-$daysAgingInt = $env:DaysAging -as [int]
-if ($null -eq $daysAgingInt) { $daysAgingInt = 7 }
-$daysAgingInt = -[math]::Abs($daysAgingInt)
+# Normalize DaysAging to a positive whole number, then negate so AddDays() walks backwards from now.
+# A non-numeric or non-positive value (e.g. "abc", "0", "-0") is meaningless for "older than N days",
+# so fall back to the default rather than silently flagging every checkpoint.
+$parsedDays = $env:DaysAging -as [int]
+if ($null -eq $parsedDays -or [math]::Abs($parsedDays) -lt 1) {
+    Write-Host "WARNING: DaysAging value '$env:DaysAging' is not a valid positive number; defaulting to $DefaultDaysAging day(s)."
+    $parsedDays = $DefaultDaysAging
+}
+$daysAging = [math]::Abs($parsedDays)
+$daysAgingNegative = -$daysAging
 
 # --- Script logic --------------------------------------------------------
 
@@ -66,7 +73,7 @@ Start-Transcript -Path $LogPath
 Write-Host "Description: $env:Description"
 Write-Host "Log path: $LogPath"
 Write-Host "RMM: $env:RMM"
-Write-Host "Days Aging: $daysAgingInt"
+Write-Host "Days Aging threshold: $daysAging day(s)"
 
 # Detect Hyper-V WITHOUT the ServerManager module / Get-WindowsFeature.
 #
@@ -88,7 +95,7 @@ if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
     Exit 0
 }
 
-$cutoff = (Get-Date).AddDays($daysAgingInt)
+$cutoff = (Get-Date).AddDays($daysAgingNegative)
 
 # Enumerate checkpoints. If this throws (e.g. insufficient privilege, WMI/vmms fault) we must
 # NOT fall through and report "no aging checkpoints" -- that would be a false all-clear that
@@ -103,12 +110,12 @@ try {
 
 if ($AgingCheckpoints) {
     $AgingCheckpoints | ForEach-Object {
-        Write-Host "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $([math]::Abs($daysAgingInt)) day(s). Created on $($_.CreationTime). Please delete this checkpoint."
+        Write-Host "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $daysAging day(s). Created on $($_.CreationTime). Please delete this checkpoint."
     }
     Stop-Transcript
     Exit 1
 } else {
-    Write-Host "There are no checkpoints older than $([math]::Abs($daysAgingInt)) day(s) that need to be deleted."
+    Write-Host "There are no checkpoints older than $daysAging day(s) that need to be deleted."
     Stop-Transcript
     Exit 0
 }


### PR DESCRIPTION
## What

Hardening pass over both Hyper-V checkpoint scripts. They already conform to the DTC template and read RMM variables via `$env:` (done in #95) — this PR builds on that.

### `hyper-v-delete-all-checkpoints.ps1`
- Wrap per-VM `Get-VMSnapshot` in try/catch (`-ErrorAction Stop`) so one VM's fault is recorded and skipped, not thrown uncaught mid-run.
- Add `-Confirm:$false` to `Remove-VMSnapshot` — never prompts regardless of host `$ConfirmPreference` (RMM is non-interactive).
- Track + report deleted/failure counts; note the AVHDX merge is async.

### `msft-windows-checkpoint-aging.ps1`
- Treat a non-numeric **or non-positive** `DaysAging` (`"abc"`, `"0"`) as invalid → fall back to default (7) with a logged warning, instead of a 0-day threshold that flags every checkpoint.
- Clearer threshold logging.

## Behavior unchanged
- Non-Hyper-V hosts still no-op cleanly via the `vmms` service + `Get-VM` guard (this is what stops the errors on non-Hyper-V endpoints).
- Exit codes unchanged: aging `1`=findings / `2`=error / `0`=clean; delete `0`=success / `1`=deletion failure.

## Testing
- `[Parser]::ParseFile` clean on both.
- Logic reviewed for interactive + RMM (`$env:RMM="1"`) paths.
- Not yet run on a live Hyper-V host — please validate against one before relying on it fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)