### PR TITLE
Revert #97 (core-isolation $env: change)

### DIFF
--- a/msft-windows/msft-windows-disable-core-isolation.ps1
+++ b/msft-windows/msft-windows-disable-core-isolation.ps1
@@ -1,8 +1,6 @@
 ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
-## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
-## $env:RMM           - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
-## $env:Description   - Ticket # or initials for audit trail
-## $env:RMMScriptPath - Optional log directory base provided by the RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $Description
 
 # This script disables Core Isolation (Memory Integrity / HVCI) which causes:
 # - 10-15% CPU performance overhead
@@ -11,36 +9,34 @@
 # - Blue screens with certain hardware/drivers
 # Core Isolation uses Virtualization Based Security (VBS) which adds significant overhead
 
-# Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
+# Getting input from user if not running from RMM else set variables from RMM.
 
 $ScriptLogName = "msft-windows-disable-core-isolation.log"
 
-# --- Input handling: RMM vs interactive ----------------------------------
-
-if ($env:RMM -ne "1") {
+if ($RMM -ne 1) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {
-        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
-        if ($env:Description) {
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
             $ValidInput = 1
         } else {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
 } else {
-    # RMM mode: store logs under $env:RMMScriptPath if the RMM provided one,
-    # otherwise fall back to the standard Windows logs directory.
-    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
-        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    # Store the logs in the RMMScriptPath
+    if ($null -ne $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
     }
 
-    if ([string]::IsNullOrEmpty($env:Description)) {
+    if ($null -eq $Description) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
-        $env:Description = "Windows Core Isolation Disable"
+        $Description = "Windows Core Isolation Disable"
     }
 }
 
@@ -60,9 +56,9 @@ try {
     Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
 }
 
-Write-Host "Description: $env:Description"
+Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
-Write-Host "RMM: $env:RMM `n"
+Write-Host "RMM: $RMM `n"
 
 Write-Host "=== Windows Core Isolation Disable Script ===" -ForegroundColor Cyan
 Write-Host "This script disables Core Isolation (Memory Integrity/HVCI) to improve performance." -ForegroundColor White
@@ -301,4 +297,3 @@ try {
 }
 
 if ($TranscriptStarted) { Stop-Transcript }
-exit 0

--- a/msft-windows/msft-windows-enable-core-isolation.ps1
+++ b/msft-windows/msft-windows-enable-core-isolation.ps1
@@ -1,43 +1,39 @@
 ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
-## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
-## $env:RMM           - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
-## $env:Description   - Ticket # or initials for audit trail
-## $env:RMMScriptPath - Optional log directory base provided by the RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $Description
 
 # This script re-enables Core Isolation (Memory Integrity / HVCI)
 # Use this to reverse the effects of msft-windows-disable-core-isolation.ps1
 # Note: On some older machines, disabling Core Isolation can cause screen flickering - this script fixes that.
 
-# Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
+# Getting input from user if not running from RMM else set variables from RMM.
 
 $ScriptLogName = "msft-windows-enable-core-isolation.log"
 
-# --- Input handling: RMM vs interactive ----------------------------------
-
-if ($env:RMM -ne "1") {
+if ($RMM -ne 1) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {
-        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
-        if ($env:Description) {
+        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
+        if ($Description) {
             $ValidInput = 1
         } else {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
+
 } else {
-    # RMM mode: store logs under $env:RMMScriptPath if the RMM provided one,
-    # otherwise fall back to the standard Windows logs directory.
-    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
-        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    # Store the logs in the RMMScriptPath
+    if ($null -ne $RMMScriptPath) {
+        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
     }
 
-    if ([string]::IsNullOrEmpty($env:Description)) {
+    if ($null -eq $Description) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
-        $env:Description = "Windows Core Isolation Enable"
+        $Description = "Windows Core Isolation Enable"
     }
 }
 
@@ -57,9 +53,9 @@ try {
     Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
 }
 
-Write-Host "Description: $env:Description"
+Write-Host "Description: $Description"
 Write-Host "Log path: $LogPath"
-Write-Host "RMM: $env:RMM `n"
+Write-Host "RMM: $RMM `n"
 
 Write-Host "=== Windows Core Isolation Enable Script ===" -ForegroundColor Cyan
 Write-Host "This script re-enables Core Isolation (Memory Integrity/HVCI)." -ForegroundColor White
@@ -244,4 +240,3 @@ try {
 }
 
 if ($TranscriptStarted) { Stop-Transcript }
-exit 0


### PR DESCRIPTION
Reverts #97 (merge commit ff87777) at the author's request — the core-isolation scripts should not have been changed in this round.

Restores `msft-windows-enable-core-isolation.ps1` and `msft-windows-disable-core-isolation.ps1` to their pre-#97 state. **Only** these two files are affected; the Hyper-V checkpoint scripts are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)