### PR TITLE
bug(checkpoints): guard Start/Stop-Transcript for the NinjaRMM host

### DIFF
--- a/msft-windows/hyper-v-delete-all-checkpoints.ps1
+++ b/msft-windows/hyper-v-delete-all-checkpoints.ps1
@@ -58,7 +58,16 @@ if (-not (Test-Path -Path $logDir)) {
 
 # --- Script logic --------------------------------------------------------
 
-Start-Transcript -Path $LogPath
+# Start-Transcript fails in some hosts (e.g. the NinjaRMM scripting host throws
+# "Transcription cannot be started"). Guard it so the script still runs and its
+# Write-Host output still reaches the RMM console; only the transcript file is lost.
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
 
 Write-Host "Description: $env:Description"
 Write-Host "Log path: $LogPath"
@@ -74,13 +83,13 @@ Write-Host "RMM: $env:RMM"
 # only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
 if (-not (Get-Service -Name "vmms" -ErrorAction SilentlyContinue)) {
     Write-Host "Hyper-V is not installed on this machine (vmms service not found)."
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }
 
 if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
     Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot manage checkpoints."
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }
 
@@ -89,13 +98,13 @@ try {
     $vmList = Get-VM -ErrorAction Stop
 } catch {
     Write-Host "ERROR: Failed to enumerate Hyper-V VMs: $_" -ForegroundColor Red
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 2
 }
 
 if (-not $vmList) {
     Write-Host "No virtual machines found on this host." -ForegroundColor Yellow
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }
 
@@ -139,10 +148,10 @@ Write-Host "Note: deleting a checkpoint triggers an AVHDX merge that completes a
 
 if ($failureCount -gt 0) {
     Write-Host "Completed with $failureCount checkpoint deletion failure(s). See log for details." -ForegroundColor Red
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 1
 }
 
 Write-Host "All checkpoints processed successfully."
-Stop-Transcript
+if ($TranscriptStarted) { Stop-Transcript }
 Exit 0

--- a/msft-windows/msft-windows-checkpoint-aging.ps1
+++ b/msft-windows/msft-windows-checkpoint-aging.ps1
@@ -68,7 +68,16 @@ $daysAgingNegative = -$daysAging
 
 # --- Script logic --------------------------------------------------------
 
-Start-Transcript -Path $LogPath
+# Start-Transcript fails in some hosts (e.g. the NinjaRMM scripting host throws
+# "Transcription cannot be started"). Guard it so the script still runs and its
+# Write-Host output still reaches the RMM console; only the transcript file is lost.
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
 
 Write-Host "Description: $env:Description"
 Write-Host "Log path: $LogPath"
@@ -85,13 +94,13 @@ Write-Host "Days Aging threshold: $daysAging day(s)"
 # only when the Hyper-V platform is installed, and both are bitness-safe on client + server.
 if (-not (Get-Service -Name "vmms" -ErrorAction SilentlyContinue)) {
     Write-Host "Hyper-V is not installed on this machine (vmms service not found)."
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }
 
 if (-not (Get-Command -Name "Get-VM" -ErrorAction SilentlyContinue)) {
     Write-Host "Hyper-V platform is present but the Hyper-V PowerShell module is not installed; cannot enumerate checkpoints."
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }
 
@@ -104,7 +113,7 @@ try {
     $AgingCheckpoints = Get-VM -ErrorAction Stop | Get-VMSnapshot -ErrorAction Stop | Where-Object { $_.CreationTime -lt $cutoff }
 } catch {
     Write-Host "ERROR: Failed to enumerate Hyper-V VMs/checkpoints: $_"
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 2
 }
 
@@ -112,10 +121,10 @@ if ($AgingCheckpoints) {
     $AgingCheckpoints | ForEach-Object {
         Write-Host "Checkpoint '$($_.Name)' on VM '$($_.VMName)' is older than $daysAging day(s). Created on $($_.CreationTime). Please delete this checkpoint."
     }
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 1
 } else {
     Write-Host "There are no checkpoints older than $daysAging day(s) that need to be deleted."
-    Stop-Transcript
+    if ($TranscriptStarted) { Stop-Transcript }
     Exit 0
 }


### PR DESCRIPTION
## Problem (observed in production)

Running the aging script via NinjaRMM produced:

```
Start-Transcript : Transcription cannot be started.
Stop-Transcript : An error occurred stopping transcription: The host is not currently transcribing.
```

The NinjaRMM scripting host rejects `Start-Transcript`; the unguarded `Stop-Transcript` calls then each error because nothing is transcribing. The script still **functions** (correctly detected no Hyper-V, exit 0) — but the RMM result is full of red error text. Both checkpoint scripts had unguarded transcript calls.

## Fix

- Wrap `Start-Transcript` in try/catch with a `$TranscriptStarted` flag; log a warning if the host won't transcribe.
- Gate every `Stop-Transcript` on `$TranscriptStarted`.
- Same pattern already used elsewhere in the repo (e.g. the core-isolation scripts).

`Write-Host` output still reaches the RMM console; only the transcript *file* is skipped when the host can't transcribe. No logic or exit-code changes.

## Testing
- `[Parser]::ParseFile` clean on both; confirmed no unguarded `Stop-Transcript` remains.
- Addresses the exact error seen in the pasted NinjaRMM output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)