### PR TITLE
bug(checkpoints): never hang on Read-Host in non-interactive RMM runs

### DIFF
--- a/msft-windows/hyper-v-delete-all-checkpoints.ps1
+++ b/msft-windows/hyper-v-delete-all-checkpoints.ps1
@@ -13,7 +13,11 @@ $ScriptLogName = "windows-hyper-v-delete-all-checkpoints.log"
 
 # --- Input handling: RMM vs interactive ----------------------------------
 
-if ($env:RMM -ne "1") {
+# Only prompt when the session is genuinely interactive. NinjaRMM runs scripts
+# non-interactively ([Environment]::UserInteractive is $false), so even if the RMM
+# preset variable is missing or renamed, we fall through to RMM mode with defaults
+# instead of blocking forever on Read-Host (which manifests as a hung RMM job).
+if ($env:RMM -ne "1" -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {

--- a/msft-windows/msft-windows-checkpoint-aging.ps1
+++ b/msft-windows/msft-windows-checkpoint-aging.ps1
@@ -18,7 +18,11 @@ if ([string]::IsNullOrEmpty($env:DaysAging)) {
 
 # --- Input handling: RMM vs interactive ----------------------------------
 
-if ($env:RMM -ne "1") {
+# Only prompt when the session is genuinely interactive. NinjaRMM runs scripts
+# non-interactively ([Environment]::UserInteractive is $false), so even if the RMM
+# preset variable is missing or renamed, we fall through to RMM mode with defaults
+# instead of blocking forever on Read-Host (which manifests as a hung RMM job).
+if ($env:RMM -ne "1" -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {


### PR DESCRIPTION
## Problem (observed in production)

`Run Windows Hyper-V Checkpoint Aging` started under NinjaRMM (Variables: `rmm = 1`) and **hung with no output** — never finished.

No output before the hang = it reached `Read-Host` and is waiting for keyboard input that never arrives in an unattended RMM session. It got there because the RMM-mode gate `if ($env:RMM -ne "1")` didn't evaluate as RMM mode (the deployed copy isn't seeing the preset as `"1"`).

## Fix

Require an *interactive session* before ever prompting:

```powershell
if ($env:RMM -ne "1" -and [Environment]::UserInteractive) { ... Read-Host ... }
else { ... RMM mode, safe defaults ... }
```

NinjaRMM runs scripts non-interactively (`[Environment]::UserInteractive` is `$false`), so even if the RMM variable is missing/renamed/not seen, the script now falls through to RMM mode and completes instead of blocking. A genuine interactive run by a tech still prompts. Applied to both checkpoint scripts. No other logic or exit-code changes.

## ⚠️ Deployment note
Your earlier run *did* read `$env:RMM = 1` and completed, so the copy hanging now is very likely a **stale version in the NinjaOne Script Library**, not `main`. After merging, **update both scripts in NinjaOne → Scripting → Library from `main`** — otherwise the old hanging copy keeps running.

## Testing
- `[Parser]::ParseFile` clean on both.
- Logic: non-interactive + any RMM-var state → RMM branch (no Read-Host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)