### PR TITLE
bug(bitlocker-suspend): stop Read-Host spam under NinjaRMM

### DIFF
--- a/msft-windows/msft-windows-suspend-bitlocker.ps1
+++ b/msft-windows/msft-windows-suspend-bitlocker.ps1
@@ -1,74 +1,95 @@
-# Getting input from user if not running from RMM else set variables from RMM.
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## NinjaRMM passes script preset variables as environment variables, so each is read via $env: in this script.
+## $env:RMM           - Set to "1" by NinjaRMM to indicate RMM (non-interactive) mode
+## $env:Description   - Ticket # or initials for audit trail
+## $env:RMMScriptPath - Optional log directory base provided by the RMM
+
+# Suspends BitLocker on all fully-encrypted volumes. RebootCount 0 = stays suspended
+# until explicitly resumed (use msft-windows-resume-bitlocker.ps1).
+
+# Standard DTC three-part structure: 1) RMM variable declaration, 2) input handling, 3) script logic.
 
 $ScriptLogName = "bitlocker-suspend.log"
 
-if ($RMM -ne 1) {
+# --- Input handling: RMM vs interactive ----------------------------------
+
+# Only prompt when the session is genuinely interactive. NinjaRMM runs scripts
+# non-interactively ([Environment]::UserInteractive is $false), so even if the RMM
+# preset variable is missing or renamed, we fall through to RMM mode with defaults
+# instead of erroring/looping forever on Read-Host in NonInteractive mode.
+if ($env:RMM -ne "1" -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {
-        # Ask for input here. This is the interactive area for getting variable information.
-        # Remember to make ValidInput = 1 whenever correct input is given.
-        $Description = Read-Host "Please enter the ticket # and, or your initials. Its used as the Description for the job"
-        if ($Description) {
+        $env:Description = Read-Host "Please enter the ticket # and/or your initials for audit trail"
+        if ($env:Description) {
             $ValidInput = 1
         } else {
             Write-Host "Invalid input. Please try again."
         }
     }
-    $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
-
-} else { 
-    # Store the logs in the RMMScriptPath
-    if ($null -eq $RMMScriptPath) {
-        $LogPath = "$RMMScriptPath\logs\$ScriptLogName"
-        
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+} else {
+    # RMM mode: store logs under $env:RMMScriptPath if the RMM provided one,
+    # otherwise fall back to the standard Windows logs directory.
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
     } else {
-        $LogPath = "$ENV:WINDIR\logs\$ScriptLogName"
-        
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
     }
 
-    if ($null -eq $Description) {
+    if ([string]::IsNullOrEmpty($env:Description)) {
         Write-Host "Description is null. This was most likely run automatically from the RMM and no information was passed."
-        $Description = "No Description"
-    }   
-
-
-    
+        $env:Description = "No Description"
+    }
 }
 
-Start-Transcript -Path $LogPath
+# Ensure log directory exists before starting the transcript
+$logDir = Split-Path -Path $LogPath -Parent
+if (-not (Test-Path -Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
 
-Write-Host "Description: $Description"
+# --- Script logic --------------------------------------------------------
+
+# Start-Transcript fails in some hosts (e.g. the NinjaRMM scripting host throws
+# "Transcription cannot be started"). Guard it so the script still runs and its
+# Write-Host output still reaches the RMM console; only the transcript file is lost.
+$TranscriptStarted = $false
+try {
+    Start-Transcript -Path $LogPath -ErrorAction Stop
+    $TranscriptStarted = $true
+} catch {
+    Write-Host "Warning: Could not start transcript logging to $LogPath - $($_.Exception.Message)"
+}
+
+Write-Host "Description: $env:Description"
 Write-Host "Log path: $LogPath"
-Write-Host "RMM: $RMM"
+Write-Host "RMM: $env:RMM"
 
-# Function to suspend BitLocker encryption on all volumes
-function Suspend-AllBitLocker {
-    try {
-        # Get all BitLocker encrypted volumes
-        $bitLockerVolumes = Get-BitLockerVolume | Where-Object { $_.VolumeStatus -eq 'FullyEncrypted' }
-
-        if ($bitLockerVolumes.Count -gt 0) {
-            foreach ($volume in $bitLockerVolumes) {
-                # Suspend BitLocker encryption
-                Suspend-BitLocker -MountPoint $volume.MountPoint -RebootCount 0 -Verbose
-
-                Write-Output "BitLocker encryption on volume $($volume.MountPoint) has been suspended."
-            }
-        } else {
-            Write-Output "No BitLocker encrypted volumes found."
-        }
-        Exit 0
-    }
-    catch {
-        Write-Error "An error occurred: $_"
-        exit 1
-    }
+# BitLocker cmdlets require the BitLocker feature/module. If absent, no-op cleanly.
+if (-not (Get-Command -Name "Get-BitLockerVolume" -ErrorAction SilentlyContinue)) {
+    Write-Host "BitLocker cmdlets are not available on this machine; nothing to suspend."
+    if ($TranscriptStarted) { Stop-Transcript }
+    Exit 0
 }
 
-# Call the function to suspend BitLocker on all volumes
-Suspend-AllBitLocker
+$exitCode = 0
+try {
+    $bitLockerVolumes = Get-BitLockerVolume -ErrorAction Stop | Where-Object { $_.VolumeStatus -eq 'FullyEncrypted' }
 
+    if ($bitLockerVolumes) {
+        foreach ($volume in $bitLockerVolumes) {
+            Suspend-BitLocker -MountPoint $volume.MountPoint -RebootCount 0 -ErrorAction Stop | Out-Null
+            Write-Host "BitLocker encryption on volume $($volume.MountPoint) has been suspended."
+        }
+    } else {
+        Write-Host "No fully-encrypted BitLocker volumes found."
+    }
+} catch {
+    Write-Host "ERROR: Failed to suspend BitLocker: $_"
+    $exitCode = 1
+}
 
-
-Stop-Transcript
+if ($TranscriptStarted) { Stop-Transcript }
+Exit $exitCode


### PR DESCRIPTION
## Problem (observed in production)

`Windows Hyper-V...` — the suspend-bitlocker script flooded its log with:
```
Read-Host : Windows PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.
... Invalid input. Please try again.  (looping)
```

Bare `$RMM` → under NinjaRMM `$RMM` is `$null`, so `if ($RMM -ne 1)` is true → interactive branch → `Read-Host` errors in NonInteractive mode → the `while` loop retries forever.

## Fix (same pattern as the checkpoint scripts)

- Read RMM vars via `$env:`; gate prompts on `$env:RMM -ne "1" -and [Environment]::UserInteractive` so a non-interactive run can never reach `Read-Host`.
- Fix the inverted `$RMMScriptPath` log-path branch.
- Guard `Start-Transcript`/`Stop-Transcript` with `$TranscriptStarted`.
- No-op cleanly when BitLocker cmdlets are absent. Suspend logic + `RebootCount 0` unchanged. Exit 0 success / 1 error.

## ⚠️ Deployment
Merging this does **not** change what NinjaOne runs — the NinjaOne Script Library copy must be updated from `main`. (There is no automated repo→NinjaOne deploy configured.)

## ⚠️ Bigger picture
**70 scripts in this repo still use the bare `if ($RMM -ne 1)` pattern** and have this same latent bug. Recommend a follow-up sweep to convert them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)