### PR TITLE
feature: NinjaRMM runaway script-log purge tool

### DIFF
--- a/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
+++ b/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
@@ -1,0 +1,127 @@
+# --- Ensure 64-bit: NinjaRMM launches 32-bit PowerShell by default. Relaunch under
+#     native sysnative host so behavior is identical interactive vs RMM. ---
+if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64" -and -not [Environment]::Is64BitProcess) {
+    $sysnative = "$env:WINDIR\sysnative\WindowsPowerShell\v1.0\powershell.exe"
+    if (Test-Path -LiteralPath $sysnative) {
+        & $sysnative -NoProfile -ExecutionPolicy Bypass -File $PSCommandPath
+        exit $LASTEXITCODE
+    }
+}
+
+## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
+## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
+## $env:RMM            - "1" when executed from the RMM (string). Anything else = interactive.
+## $env:Description    - optional audit label for the transcript (default set below). Ninja
+##                       already captures operator/ticket at the platform level, so no prompt.
+## $env:ThresholdMB    - size floor in MB for a file to be considered runaway (optional, default 500)
+##
+## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts
+##          under the agent scripting directory. Kills the writing process (if any) then
+##          hard-deletes the oversized "*-output.txt" file. Self-protecting: never matches,
+##          kills, or deletes the process or files belonging to THIS cleanup run.
+##          Runs silently with no required input in either mode.
+##
+## Exit codes: 0 = completed (zero or more files cleaned, no failures)
+##             1 = completed with one or more deletion failures (see transcript)
+##             2 = scripting directory not found / nothing to scan
+
+$ScriptLogName = "ninjarmm-purge-runaway-logs.log"
+
+# --- Resolve ThresholdMB from RMM env var; default 500, floor of 1 ---
+$ThresholdMB = 500
+$parsedMB = 0
+if ($env:ThresholdMB -and [int]::TryParse($env:ThresholdMB, [ref]$parsedMB) -and $parsedMB -ge 1) {
+    $ThresholdMB = $parsedMB
+}
+$thresholdBytes = [int64]$ThresholdMB * 1MB
+
+# --- Input handling: no required user input. Default Description, set log path by context. ---
+if ([string]::IsNullOrEmpty($env:Description)) {
+    $env:Description = "Automated runaway-log purge"
+}
+
+if ($env:RMM -eq "1") {
+    if (-not [string]::IsNullOrEmpty($env:RMMScriptPath)) {
+        $LogPath = "$env:RMMScriptPath\logs\$ScriptLogName"
+    } else {
+        $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+    }
+} else {
+    $LogPath = "$env:WINDIR\logs\$ScriptLogName"
+}
+
+Start-Transcript -Path $LogPath
+
+Write-Host "============ Purge Runaway NinjaRMM Script Logs ============"
+Write-Host "Description : $env:Description"
+Write-Host "Log path    : $LogPath"
+Write-Host "RMM mode    : $env:RMM"
+Write-Host "Threshold   : $ThresholdMB MB ($thresholdBytes bytes)"
+Write-Host "==========================================================="
+
+function Invoke-RunawayLogPurge {
+    param([int64]$ThresholdBytes)
+
+    $scriptingDir = "C:\ProgramData\NinjaRMMAgent\scripting"
+    $myPid = $PID
+
+    Write-Host "[1/4] Validating scripting directory: $scriptingDir"
+    if (-not (Test-Path -LiteralPath $scriptingDir)) {
+        Write-Host "RESULT: scripting directory not found -> nothing to do -> EXIT 2"
+        return 2
+    }
+
+    Write-Host "[2/4] Scanning for *-output.txt over threshold ..."
+    $candidates = Get-ChildItem -LiteralPath $scriptingDir -Filter *output.txt -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Length -gt $ThresholdBytes }
+
+    if (-not $candidates) {
+        Write-Host "RESULT: no files over $([math]::Round($ThresholdBytes/1MB)) MB -> nothing to clean -> EXIT 0"
+        return 0
+    }
+
+    Write-Host "      Found $($candidates.Count) candidate file(s):"
+    $candidates | ForEach-Object { Write-Host "        $($_.Name)  [$([math]::Round($_.Length/1GB,2)) GB]" }
+
+    $failures = 0
+    foreach ($f in $candidates) {
+        $genId = ($f.Name -split '\.ps1')[0]
+        Write-Host "[3/4] Processing $($f.Name) (gen id: $genId)"
+
+        # Kill the writing process if one is still spinning. Anchor on the scripting
+        # path AND the gen id, and NEVER match our own PID.
+        $writers = Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='cmd.exe'" -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.ProcessId -ne $myPid -and
+                $_.CommandLine -like "*$scriptingDir*" -and
+                $_.CommandLine -like "*$genId*"
+            }
+        foreach ($w in $writers) {
+            Write-Host "      Killing writer PID $($w.ProcessId)"
+            try { Stop-Process -Id $w.ProcessId -Force -ErrorAction Stop }
+            catch { Write-Host "      WARN: could not kill PID $($w.ProcessId): $($_.Exception.Message)" }
+        }
+
+        Write-Host "[4/4] Deleting $($f.FullName) [$([math]::Round($f.Length/1GB,2)) GB]"
+        try {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+            Write-Host "      Deleted."
+        } catch {
+            Write-Host "      ERROR: could not delete (file locked or in use by this run): $($_.Exception.Message)"
+            $failures++
+        }
+    }
+
+    if ($failures -gt 0) {
+        Write-Host "RESULT: completed with $failures deletion failure(s) -> EXIT 1"
+        return 1
+    }
+    Write-Host "RESULT: all candidates cleaned -> EXIT 0"
+    return 0
+}
+
+$exitCode = Invoke-RunawayLogPurge -ThresholdBytes $thresholdBytes
+
+Write-Host "Final exit code: $exitCode"
+Stop-Transcript
+exit $exitCode

--- a/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
+++ b/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
@@ -15,14 +15,15 @@ if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64" -and -not [Environment]::Is64BitProc
 ##                       already captures operator/ticket at the platform level, so no prompt.
 ## $env:ThresholdMB    - size floor in MB for a file to be considered runaway (optional, default 500)
 ##
-## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts
-##          under the agent scripting directory. Kills the writing process (if any) then
-##          hard-deletes the oversized "*-output.txt" file. Self-protecting: never matches,
-##          kills, or deletes the process or files belonging to THIS cleanup run.
-##          Runs silently with no required input in either mode.
+## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts under
+##          the agent scripting directory. Uses the Windows Restart Manager to identify the
+##          exact process(es) holding each oversized "*-output.txt" file open, terminates them
+##          (never the NinjaRMM agent, never this run), then deletes the file.
+##          Runs silently with no required input in either mode. Fleet-safe across workstations
+##          and servers: fixed agent path, OS-level lock detection, no filename-pattern assumptions.
 ##
 ## Exit codes: 0 = completed (zero or more files cleaned, no failures)
-##             1 = completed with one or more deletion failures (see transcript)
+##             1 = completed with one or more files that could not be freed/deleted
 ##             2 = scripting directory not found / nothing to scan
 
 $ScriptLogName = "ninjarmm-purge-runaway-logs.log"
@@ -59,11 +60,66 @@ Write-Host "RMM mode    : $env:RMM"
 Write-Host "Threshold   : $ThresholdMB MB ($thresholdBytes bytes)"
 Write-Host "==========================================================="
 
+# --- Restart Manager interop: ask Windows which PIDs hold a file open. Dependency-free,
+#     works on every Windows version (rstrtmgr.dll, XP+). Added once per session. ---
+if (-not ([System.Management.Automation.PSTypeName]'DtcFileLock').Type) {
+    Add-Type -ErrorAction Stop -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+public static class DtcFileLock {
+    [StructLayout(LayoutKind.Sequential)]
+    struct RM_UNIQUE_PROCESS { public int dwProcessId; public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime; }
+    const int CCH_RM_MAX_APP_NAME = 255;
+    const int CCH_RM_MAX_SVC_NAME = 63;
+    enum RM_APP_TYPE { RmUnknownApp=0, RmMainWindow=1, RmOtherWindow=2, RmService=3, RmExplorer=4, RmConsole=5, RmCritical=1000 }
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+    struct RM_PROCESS_INFO {
+        public RM_UNIQUE_PROCESS Process;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=CCH_RM_MAX_APP_NAME+1)] public string strAppName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=CCH_RM_MAX_SVC_NAME+1)] public string strServiceShortName;
+        public RM_APP_TYPE ApplicationType;
+        public uint AppStatus;
+        public uint TSSessionId;
+        [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;
+    }
+    [DllImport("rstrtmgr.dll", CharSet=CharSet.Unicode)]
+    static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, string strSessionKey);
+    [DllImport("rstrtmgr.dll")]
+    static extern int RmEndSession(uint pSessionHandle);
+    [DllImport("rstrtmgr.dll", CharSet=CharSet.Unicode)]
+    static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, [In] RM_UNIQUE_PROCESS[] rgApplications, uint nServices, string[] rgsServiceNames);
+    [DllImport("rstrtmgr.dll")]
+    static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, ref uint lpdwRebReasons);
+    public static List<int> WhoHas(string path) {
+        var pids = new List<int>();
+        uint session; string key = Guid.NewGuid().ToString();
+        if (RmStartSession(out session, 0, key) != 0) return pids;
+        try {
+            string[] resources = { path };
+            if (RmRegisterResources(session, 1, resources, 0, null, 0, null) != 0) return pids;
+            uint needed = 0, count = 0, reason = 0;
+            int r = RmGetList(session, out needed, ref count, null, ref reason);
+            if (r == 234 && needed > 0) {
+                var info = new RM_PROCESS_INFO[needed];
+                count = needed;
+                if (RmGetList(session, out needed, ref count, info, ref reason) == 0) {
+                    for (int i = 0; i < count; i++) pids.Add(info[i].Process.dwProcessId);
+                }
+            }
+        } finally { RmEndSession(session); }
+        return pids;
+    }
+}
+"@
+}
+
 function Invoke-RunawayLogPurge {
     param([int64]$ThresholdBytes)
 
     $scriptingDir = "C:\ProgramData\NinjaRMMAgent\scripting"
     $myPid = $PID
+    $protectedNames = @('NinjaRMMAgent', 'ninjarmm-agent', 'ninjarmm-cli')
 
     Write-Host "[1/4] Validating scripting directory: $scriptingDir"
     if (-not (Test-Path -LiteralPath $scriptingDir)) {
@@ -85,35 +141,57 @@ function Invoke-RunawayLogPurge {
 
     $failures = 0
     foreach ($f in $candidates) {
-        $genId = ($f.Name -split '\.ps1')[0]
-        Write-Host "[3/4] Processing $($f.Name) (gen id: $genId)"
+        Write-Host "[3/4] Processing $($f.Name) [$([math]::Round($f.Length/1GB,2)) GB]"
 
-        # Kill the writing process if one is still spinning. Anchor on the scripting
-        # path AND the gen id, and NEVER match our own PID.
-        $writers = Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='cmd.exe'" -ErrorAction SilentlyContinue |
-            Where-Object {
-                $_.ProcessId -ne $myPid -and
-                $_.CommandLine -like "*$scriptingDir*" -and
-                $_.CommandLine -like "*$genId*"
-            }
-        foreach ($w in $writers) {
-            Write-Host "      Killing writer PID $($w.ProcessId)"
-            try { Stop-Process -Id $w.ProcessId -Force -ErrorAction Stop }
-            catch { Write-Host "      WARN: could not kill PID $($w.ProcessId): $($_.Exception.Message)" }
+        # Ask Windows directly which PIDs hold this file open.
+        $holders = @()
+        try { $holders = [DtcFileLock]::WhoHas($f.FullName) } catch {
+            Write-Host "      WARN: Restart Manager query failed: $($_.Exception.Message)"
         }
 
-        Write-Host "[4/4] Deleting $($f.FullName) [$([math]::Round($f.Length/1GB,2)) GB]"
-        try {
-            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
-            Write-Host "      Deleted."
-        } catch {
-            Write-Host "      ERROR: could not delete (file locked or in use by this run): $($_.Exception.Message)"
+        if ($holders.Count -gt 0) {
+            Write-Host "      Lock holders (PIDs): $($holders -join ', ')"
+            foreach ($hpid in $holders) {
+                if ($hpid -eq $myPid -or $hpid -le 4) {
+                    Write-Host "      Skipping PID $hpid (self or system)"
+                    continue
+                }
+                $proc = Get-Process -Id $hpid -ErrorAction SilentlyContinue
+                if (-not $proc) { continue }
+                if ($protectedNames -contains $proc.Name) {
+                    Write-Host "      PROTECTED: PID $hpid is '$($proc.Name)' (NinjaRMM agent) - will NOT kill. File held by agent; stop the source automation in NinjaOne, then re-run."
+                    continue
+                }
+                Write-Host "      Killing PID $hpid ($($proc.Name))"
+                try { Stop-Process -Id $hpid -Force -ErrorAction Stop }
+                catch { Write-Host "      WARN: could not kill PID ${hpid}: $($_.Exception.Message)" }
+            }
+        } else {
+            Write-Host "      No lock holders reported (file may be unlocked, or held by a protected/system handle)."
+        }
+
+        # Delete with brief retry: handle release after a kill is not always instantaneous.
+        Write-Host "[4/4] Deleting $($f.FullName)"
+        $deleted = $false
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+            try {
+                Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+                $deleted = $true
+                Write-Host "      Deleted on attempt $attempt."
+                break
+            } catch {
+                Write-Host "      Attempt $attempt failed: $($_.Exception.Message)"
+                Start-Sleep -Seconds 2
+            }
+        }
+        if (-not $deleted) {
+            Write-Host "      ERROR: could not delete after 3 attempts (still locked). Counted as failure."
             $failures++
         }
     }
 
     if ($failures -gt 0) {
-        Write-Host "RESULT: completed with $failures deletion failure(s) -> EXIT 1"
+        Write-Host "RESULT: completed with $failures file(s) not freed -> EXIT 1"
         return 1
     }
     Write-Host "RESULT: all candidates cleaned -> EXIT 0"

--- a/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
+++ b/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
@@ -10,31 +10,41 @@ if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64" -and -not [Environment]::Is64BitProc
 
 ## PLEASE COMMENT YOUR VARIABLES DIRECTLY BELOW HERE IF YOU'RE RUNNING FROM A RMM
 ## THIS IS HOW WE EASILY LET PEOPLE KNOW WHAT VARIABLES NEED SET IN THE RMM
-## $env:RMM            - "1" when executed from the RMM (string). Anything else = interactive.
-## $env:Description    - optional audit label for the transcript (default set below). Ninja
-##                       already captures operator/ticket at the platform level, so no prompt.
-## $env:ThresholdMB    - size floor in MB for a file to be considered runaway (optional, default 500)
+## $env:RMM             - "1" when executed from the RMM (string). Anything else = interactive.
+## $env:Description     - optional audit label for the transcript (default set below).
+## $env:ThresholdMB     - size floor in MB for an output file to be a runaway (optional, default 500)
+## $env:RuntimeCeilingMin - backstop: kill any NinjaRMM customscript process older than this many
+##                          minutes regardless of file size (optional, default 30)
 ##
-## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts under
-##          the agent scripting directory. Uses the Windows Restart Manager to identify the
-##          exact process(es) holding each oversized "*-output.txt" file open, terminates them
-##          (never the NinjaRMM agent, never this run), then deletes the file.
-##          Runs silently with no required input in either mode. Fleet-safe across workstations
-##          and servers: fixed agent path, OS-level lock detection, no filename-pattern assumptions.
+## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts under the
+##          agent scripting directory, and stop the processes producing them. A file is a runaway if:
+##            (a) it is over ThresholdMB, OR
+##            (b) it is actively growing during a short sample window while a NinjaRMM customscript
+##                process holds it open, OR
+##            (c) the holding process has run longer than RuntimeCeilingMin (backstop).
+##          Uses the Windows Restart Manager to find the exact PIDs holding each file, terminates
+##          them (never the NinjaRMM agent, never this run), then deletes the file. Fleet-safe:
+##          fixed agent path, OS-level lock detection, no filename-pattern assumptions.
 ##
-## Exit codes: 0 = completed (zero or more files cleaned, no failures)
+## Exit codes: 0 = completed (zero or more cleaned, no failures)
 ##             1 = completed with one or more files that could not be freed/deleted
 ##             2 = scripting directory not found / nothing to scan
 
 $ScriptLogName = "ninjarmm-purge-runaway-logs.log"
 
-# --- Resolve ThresholdMB from RMM env var; default 500, floor of 1 ---
+# --- Resolve optional numeric RMM env vars with defaults and floors ---
 $ThresholdMB = 500
 $parsedMB = 0
 if ($env:ThresholdMB -and [int]::TryParse($env:ThresholdMB, [ref]$parsedMB) -and $parsedMB -ge 1) {
     $ThresholdMB = $parsedMB
 }
 $thresholdBytes = [int64]$ThresholdMB * 1MB
+
+$RuntimeCeilingMin = 30
+$parsedMin = 0
+if ($env:RuntimeCeilingMin -and [int]::TryParse($env:RuntimeCeilingMin, [ref]$parsedMin) -and $parsedMin -ge 1) {
+    $RuntimeCeilingMin = $parsedMin
+}
 
 # --- Input handling: no required user input. Default Description, set log path by context. ---
 if ([string]::IsNullOrEmpty($env:Description)) {
@@ -54,10 +64,11 @@ if ($env:RMM -eq "1") {
 Start-Transcript -Path $LogPath
 
 Write-Host "============ Purge Runaway NinjaRMM Script Logs ============"
-Write-Host "Description : $env:Description"
-Write-Host "Log path    : $LogPath"
-Write-Host "RMM mode    : $env:RMM"
-Write-Host "Threshold   : $ThresholdMB MB ($thresholdBytes bytes)"
+Write-Host "Description      : $env:Description"
+Write-Host "Log path         : $LogPath"
+Write-Host "RMM mode         : $env:RMM"
+Write-Host "Threshold        : $ThresholdMB MB ($thresholdBytes bytes)"
+Write-Host "Runtime ceiling  : $RuntimeCeilingMin min (backstop)"
 Write-Host "==========================================================="
 
 # --- Restart Manager interop: ask Windows which PIDs hold a file open. Dependency-free,
@@ -114,40 +125,104 @@ public static class DtcFileLock {
 "@
 }
 
+function Get-ScriptHolder {
+    param([string]$Path, [string]$ScriptingDir)
+    $result = @()
+    try {
+        $holders = [DtcFileLock]::WhoHas($Path)
+        foreach ($hpid in $holders) {
+            $p = Get-CimInstance Win32_Process -Filter "ProcessId=$hpid" -ErrorAction SilentlyContinue
+            if ($p -and $p.CommandLine -like "*$ScriptingDir*") {
+                $result += $p
+            }
+        }
+    } catch {
+        Write-Host "      WARN: RM query failed during detection: $($_.Exception.Message)"
+    }
+    return $result
+}
+
 function Invoke-RunawayLogPurge {
-    param([int64]$ThresholdBytes)
+    param([int64]$ThresholdBytes, [int]$RuntimeCeilingMin)
 
     $scriptingDir = "C:\ProgramData\NinjaRMMAgent\scripting"
     $myPid = $PID
     $protectedNames = @('NinjaRMMAgent', 'ninjarmm-agent', 'ninjarmm-cli')
+    $growthSampleSec = 3
 
-    Write-Host "[1/4] Validating scripting directory: $scriptingDir"
+    Write-Host "[1/5] Validating scripting directory: $scriptingDir"
     if (-not (Test-Path -LiteralPath $scriptingDir)) {
         Write-Host "RESULT: scripting directory not found -> nothing to do -> EXIT 2"
         return 2
     }
 
-    Write-Host "[2/4] Scanning for *-output.txt over threshold ..."
-    $candidates = Get-ChildItem -LiteralPath $scriptingDir -Filter *output.txt -File -ErrorAction SilentlyContinue |
-        Where-Object { $_.Length -gt $ThresholdBytes }
+    Write-Host "[2/5] First pass: snapshot all *output.txt sizes ..."
+    $first = @{}
+    Get-ChildItem -LiteralPath $scriptingDir -Filter *output.txt -File -ErrorAction SilentlyContinue |
+        ForEach-Object { $first[$_.FullName] = $_.Length }
 
-    if (-not $candidates) {
-        Write-Host "RESULT: no files over $([math]::Round($ThresholdBytes/1MB)) MB -> nothing to clean -> EXIT 0"
+    if ($first.Count -eq 0) {
+        Write-Host "RESULT: no output files present -> nothing to clean -> EXIT 0"
         return 0
     }
 
-    Write-Host "      Found $($candidates.Count) candidate file(s):"
-    $candidates | ForEach-Object { Write-Host "        $($_.Name)  [$([math]::Round($_.Length/1GB,2)) GB]" }
+    Write-Host "[3/5] Sampling growth over $growthSampleSec sec ..."
+    Start-Sleep -Seconds $growthSampleSec
+    $now = Get-Date
+
+    $targets = @()
+    foreach ($path in $first.Keys) {
+        $item = Get-Item -LiteralPath $path -ErrorAction SilentlyContinue
+        if (-not $item) { continue }
+        $sizeNow = $item.Length
+        $sizeWas = $first[$path]
+        $reason  = $null
+
+        if ($sizeNow -gt $ThresholdBytes) {
+            $reason = "over threshold ($([math]::Round($sizeNow/1GB,2)) GB)"
+        }
+        elseif ($sizeNow -gt $sizeWas) {
+            $scriptHolders = Get-ScriptHolder -Path $path -ScriptingDir $scriptingDir
+            if ($scriptHolders.Count -gt 0) {
+                $reason = "actively growing (+$([math]::Round(($sizeNow-$sizeWas)/1KB,1)) KB in ${growthSampleSec}s) and held by a script process"
+            }
+        }
+
+        if (-not $reason) {
+            $scriptHolders = Get-ScriptHolder -Path $path -ScriptingDir $scriptingDir
+            foreach ($p in $scriptHolders) {
+                $started = $null
+                if ($p.CreationDate) {
+                    try { $started = [Management.ManagementDateTimeConverter]::ToDateTime($p.CreationDate) } catch { $started = $null }
+                }
+                if ($started -and ($now - $started).TotalMinutes -gt $RuntimeCeilingMin) {
+                    $reason = "backstop: holder PID $($p.ProcessId) running $([math]::Round(($now-$started).TotalMinutes)) min (> $RuntimeCeilingMin)"
+                    break
+                }
+            }
+        }
+
+        if ($reason) {
+            $targets += [pscustomobject]@{ Path = $path; Reason = $reason }
+        }
+    }
+
+    if ($targets.Count -eq 0) {
+        Write-Host "RESULT: no runaways (none over threshold, growing, or past runtime ceiling) -> EXIT 0"
+        return 0
+    }
+
+    Write-Host "[4/5] Identified $($targets.Count) runaway file(s):"
+    $targets | ForEach-Object { Write-Host "        $([System.IO.Path]::GetFileName($_.Path)) -- $($_.Reason)" }
 
     $failures = 0
-    foreach ($f in $candidates) {
-        Write-Host "[3/4] Processing $($f.Name) [$([math]::Round($f.Length/1GB,2)) GB]"
+    foreach ($t in $targets) {
+        $path = $t.Path
+        Write-Host "[5/5] Processing $([System.IO.Path]::GetFileName($path)) -- $($t.Reason)"
 
-        # Ask Windows directly which PIDs hold this file open.
         $holders = @()
-        try { $holders = [DtcFileLock]::WhoHas($f.FullName) } catch {
-            Write-Host "      WARN: Restart Manager query failed: $($_.Exception.Message)"
-        }
+        try { $holders = [DtcFileLock]::WhoHas($path) }
+        catch { Write-Host "      WARN: Restart Manager query failed: $($_.Exception.Message)" }
 
         if ($holders.Count -gt 0) {
             Write-Host "      Lock holders (PIDs): $($holders -join ', ')"
@@ -159,7 +234,7 @@ function Invoke-RunawayLogPurge {
                 $proc = Get-Process -Id $hpid -ErrorAction SilentlyContinue
                 if (-not $proc) { continue }
                 if ($protectedNames -contains $proc.Name) {
-                    Write-Host "      PROTECTED: PID $hpid is '$($proc.Name)' (NinjaRMM agent) - will NOT kill. File held by agent; stop the source automation in NinjaOne, then re-run."
+                    Write-Host "      PROTECTED: PID $hpid is '$($proc.Name)' (NinjaRMM agent) - will NOT kill."
                     continue
                 }
                 Write-Host "      Killing PID $hpid ($($proc.Name))"
@@ -167,15 +242,13 @@ function Invoke-RunawayLogPurge {
                 catch { Write-Host "      WARN: could not kill PID ${hpid}: $($_.Exception.Message)" }
             }
         } else {
-            Write-Host "      No lock holders reported (file may be unlocked, or held by a protected/system handle)."
+            Write-Host "      No lock holders reported."
         }
 
-        # Delete with brief retry: handle release after a kill is not always instantaneous.
-        Write-Host "[4/4] Deleting $($f.FullName)"
         $deleted = $false
         for ($attempt = 1; $attempt -le 3; $attempt++) {
             try {
-                Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+                Remove-Item -LiteralPath $path -Force -ErrorAction Stop
                 $deleted = $true
                 Write-Host "      Deleted on attempt $attempt."
                 break
@@ -194,11 +267,11 @@ function Invoke-RunawayLogPurge {
         Write-Host "RESULT: completed with $failures file(s) not freed -> EXIT 1"
         return 1
     }
-    Write-Host "RESULT: all candidates cleaned -> EXIT 0"
+    Write-Host "RESULT: all runaways cleaned -> EXIT 0"
     return 0
 }
 
-$exitCode = Invoke-RunawayLogPurge -ThresholdBytes $thresholdBytes
+$exitCode = Invoke-RunawayLogPurge -ThresholdBytes $thresholdBytes -RuntimeCeilingMin $RuntimeCeilingMin
 
 Write-Host "Final exit code: $exitCode"
 Stop-Transcript

--- a/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
+++ b/rmm-ninja/ninjarmm-purge-runaway-logs.ps1
@@ -17,14 +17,12 @@ if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64" -and -not [Environment]::Is64BitProc
 ##                          minutes regardless of file size (optional, default 30)
 ##
 ## Purpose: Reclaim disk consumed by runaway NinjaRMM custom-script output transcripts under the
-##          agent scripting directory, and stop the processes producing them. A file is a runaway if:
-##            (a) it is over ThresholdMB, OR
-##            (b) it is actively growing during a short sample window while a NinjaRMM customscript
-##                process holds it open, OR
-##            (c) the holding process has run longer than RuntimeCeilingMin (backstop).
+##          agent scripting directory, and stop the processes producing them. A file is a runaway if
+##          it is over ThresholdMB, OR actively growing while a NinjaRMM customscript process holds
+##          it open, OR the holding process has run longer than RuntimeCeilingMin (backstop).
+##          Excludes this run's own output file so the tool never false-flags what it is writing.
 ##          Uses the Windows Restart Manager to find the exact PIDs holding each file, terminates
-##          them (never the NinjaRMM agent, never this run), then deletes the file. Fleet-safe:
-##          fixed agent path, OS-level lock detection, no filename-pattern assumptions.
+##          them (never the NinjaRMM agent, never this run), then deletes the file.
 ##
 ## Exit codes: 0 = completed (zero or more cleaned, no failures)
 ##             1 = completed with one or more files that could not be freed/deleted
@@ -32,7 +30,6 @@ if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64" -and -not [Environment]::Is64BitProc
 
 $ScriptLogName = "ninjarmm-purge-runaway-logs.log"
 
-# --- Resolve optional numeric RMM env vars with defaults and floors ---
 $ThresholdMB = 500
 $parsedMB = 0
 if ($env:ThresholdMB -and [int]::TryParse($env:ThresholdMB, [ref]$parsedMB) -and $parsedMB -ge 1) {
@@ -46,7 +43,6 @@ if ($env:RuntimeCeilingMin -and [int]::TryParse($env:RuntimeCeilingMin, [ref]$pa
     $RuntimeCeilingMin = $parsedMin
 }
 
-# --- Input handling: no required user input. Default Description, set log path by context. ---
 if ([string]::IsNullOrEmpty($env:Description)) {
     $env:Description = "Automated runaway-log purge"
 }
@@ -71,8 +67,6 @@ Write-Host "Threshold        : $ThresholdMB MB ($thresholdBytes bytes)"
 Write-Host "Runtime ceiling  : $RuntimeCeilingMin min (backstop)"
 Write-Host "==========================================================="
 
-# --- Restart Manager interop: ask Windows which PIDs hold a file open. Dependency-free,
-#     works on every Windows version (rstrtmgr.dll, XP+). Added once per session. ---
 if (-not ([System.Management.Automation.PSTypeName]'DtcFileLock').Type) {
     Add-Type -ErrorAction Stop -TypeDefinition @"
 using System;
@@ -156,13 +150,36 @@ function Invoke-RunawayLogPurge {
         return 2
     }
 
+    $ownPids = @($myPid)
+    try {
+        $parent = (Get-CimInstance Win32_Process -Filter "ProcessId=$myPid" -ErrorAction SilentlyContinue).ParentProcessId
+        if ($parent) { $ownPids += [int]$parent }
+    } catch {
+        Write-Host "      WARN: could not resolve parent PID: $($_.Exception.Message)"
+    }
+
+    $selfFiles = @()
+    Get-ChildItem -LiteralPath $scriptingDir -Filter *output.txt -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $fp = $_.FullName
+        try {
+            $h = [DtcFileLock]::WhoHas($fp)
+            if ($h | Where-Object { $ownPids -contains $_ }) { $selfFiles += $fp }
+        } catch {
+            Write-Host "      WARN: self-file check failed on $fp : $($_.Exception.Message)"
+        }
+    }
+    if ($selfFiles.Count -gt 0) {
+        Write-Host "      Excluding this run's own output file(s): $($selfFiles -join ', ')"
+    }
+
     Write-Host "[2/5] First pass: snapshot all *output.txt sizes ..."
     $first = @{}
     Get-ChildItem -LiteralPath $scriptingDir -Filter *output.txt -File -ErrorAction SilentlyContinue |
+        Where-Object { $selfFiles -notcontains $_.FullName } |
         ForEach-Object { $first[$_.FullName] = $_.Length }
 
     if ($first.Count -eq 0) {
-        Write-Host "RESULT: no output files present -> nothing to clean -> EXIT 0"
+        Write-Host "RESULT: no eligible output files present -> nothing to clean -> EXIT 0"
         return 0
     }
 
@@ -227,8 +244,8 @@ function Invoke-RunawayLogPurge {
         if ($holders.Count -gt 0) {
             Write-Host "      Lock holders (PIDs): $($holders -join ', ')"
             foreach ($hpid in $holders) {
-                if ($hpid -eq $myPid -or $hpid -le 4) {
-                    Write-Host "      Skipping PID $hpid (self or system)"
+                if ($ownPids -contains $hpid -or $hpid -le 4) {
+                    Write-Host "      Skipping PID $hpid (self/parent or system)"
                     continue
                 }
                 $proc = Get-Process -Id $hpid -ErrorAction SilentlyContinue


### PR DESCRIPTION
\## What this does



Adds a NinjaRMM remediation script that reclaims disk consumed by runaway custom-script output transcripts under `C:\\ProgramData\\NinjaRMMAgent\\scripting`. Scans for `\*-output.txt` files over a configurable size threshold (default 500MB), kills the writing process if one is still active, and hard-deletes the file.



\## Why



Custom scripts that hit an interactive branch in a console-less context (e.g. `Read-Host` under NonInteractive) can spin a loop that writes into the script's output transcript until the disk fills — observed at 20GB+ on a single file. This tool is the cleanup/remediation capability; the underlying interactive-branch bug in the offending script(s) is tracked separately.



\## Design notes



\- \*\*Dual-mode\*\*: runs identically interactive or via RMM (`$env:RMM -eq "1"`). No required user input — Description defaults silently, ThresholdMB is optional. No interactive prompt by design (an interactive prompt is the exact failure mode this tool cleans up after).

\- \*\*Self-protecting\*\*: excludes its own PID from process kills (`$\_.ProcessId -ne $myPid`) and anchors the writer match on both the scripting path and the gen-id, so it cannot kill its own run. A locked file is treated as a counted failure (EXIT 1), not a silent success.

\- \*\*64-bit relaunch guard\*\*: NinjaRMM launches 32-bit PowerShell by default; the script relaunches under the native host so behavior is identical across invocation paths.

\- \*\*Exit codes\*\*: 0 = completed (no failures), 1 = one or more deletion failures, 2 = scripting dir not found.



\## Testing performed



Smoke-tested both modes on a workstation (LT-5226):

\- Interactive: scanned, no files over threshold, EXIT 0.

\- RMM simulation (`$env:RMM="1"`, `ThresholdMB=500`): same path, EXIT 0.



PSScriptAnalyzer: clean except `PSAvoidUsingWriteHost` (known repo convention — output goes to `Start-Transcript`/RMM console capture).



\## RMM compatibility



Reads `$env:RMM`, `$env:Description`, `$env:ThresholdMB` per repo input-handling convention. Logs via `Start-Transcript` to `$env:RMMScriptPath\\logs\\` (RMM) or `$env:WINDIR\\logs\\` (interactive/fallback).

