### PR TITLE
improvement(non-interactive): make UserInteractive prompt-gate the standard (docs + core-isolation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ All scripts follow a consistent three-part structure defined in `script-template
 
 2. **Input Handling Section**
    - **All RMM-supplied variables come via environment variables** (`$env:VarName`). NinjaRMM passes script preset variables to PowerShell as environment variables, so the script must read them via `$env:` at every use site. Bare `$VarName` references resolve to `$null` in true RMM mode and silently fall through to the interactive branch.
-   - Detects execution context via `$env:RMM` — environment variables are strings, so compare against `"1"` not `1`. Anything other than `"1"` is interactive mode.
+   - Detects execution context via `$env:RMM` — environment variables are strings, so compare against `"1"` not `1`.
+   - **Gate the interactive branch on an interactive session too:** `if ($env:RMM -ne "1" -and [Environment]::UserInteractive)`. NinjaRMM runs scripts non-interactively (`[Environment]::UserInteractive` is `$false`), so if the RMM preset variable is ever missing, renamed, or not seen as `"1"`, the script still falls through to RMM mode instead of erroring/looping forever on `Read-Host` (`"Windows PowerShell is in NonInteractive mode. Read and Prompt functionality is not available."`). Never gate solely on `$env:RMM` — a single missing variable should never be able to hang an unattended job.
    - Interactive mode: Prompts user with `Read-Host` for required inputs with validation loop. Write the result back to `$env:Description` so the rest of the script can keep referencing `$env:` consistently.
    - RMM mode: Uses pre-set environment variables passed by the RMM platform. Defaults for any optional variables (custom field names, state file paths, etc.) should be set at the top of the script by writing to `$env:` directly:
      ```powershell

--- a/msft-windows/msft-windows-disable-core-isolation.ps1
+++ b/msft-windows/msft-windows-disable-core-isolation.ps1
@@ -13,7 +13,10 @@
 
 $ScriptLogName = "msft-windows-disable-core-isolation.log"
 
-if ($RMM -ne 1) {
+# Only prompt when the session is genuinely interactive. NinjaRMM runs non-interactively
+# ([Environment]::UserInteractive is $false), so a non-interactive run never reaches Read-Host
+# (which errors with "Windows PowerShell is in NonInteractive mode" and loops forever).
+if ($RMM -ne 1 -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {

--- a/msft-windows/msft-windows-enable-core-isolation.ps1
+++ b/msft-windows/msft-windows-enable-core-isolation.ps1
@@ -10,7 +10,10 @@
 
 $ScriptLogName = "msft-windows-enable-core-isolation.log"
 
-if ($RMM -ne 1) {
+# Only prompt when the session is genuinely interactive. NinjaRMM runs non-interactively
+# ([Environment]::UserInteractive is $false), so a non-interactive run never reaches Read-Host
+# (which errors with "Windows PowerShell is in NonInteractive mode" and loops forever).
+if ($RMM -ne 1 -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {

--- a/script-template-powershell.ps1
+++ b/script-template-powershell.ps1
@@ -41,7 +41,10 @@ $ScriptLogName = "EnterLogNameHere.log"
 
 # --- Input handling: RMM vs interactive ----------------------------------
 
-if ($env:RMM -ne "1") {
+# Only prompt in a genuinely interactive session. NinjaRMM runs non-interactively
+# ([Environment]::UserInteractive is $false), so a missing/renamed RMM variable can never
+# leave the script erroring/looping on Read-Host in NonInteractive mode.
+if ($env:RMM -ne "1" -and [Environment]::UserInteractive) {
     $ValidInput = 0
     # Checking for valid input.
     while ($ValidInput -ne 1) {


### PR DESCRIPTION
## What

Adopt `if ($env:RMM -ne "1" -and [Environment]::UserInteractive)` as the standard input-handling gate, so a missing/renamed/unseen RMM variable can never leave a script stuck on `Read-Host` ("Windows PowerShell is in NonInteractive mode") in an unattended NinjaRMM run.

- **CLAUDE.md** — document the gate as the standard; "never gate solely on `$env:RMM`."
- **script-template-powershell.ps1** — template gate updated to match.
- **msft-windows-enable-core-isolation.ps1 / -disable-core-isolation.ps1** — added **only** the `-and [Environment]::UserInteractive` part; bare `$RMM` left as-is per the earlier revert (#98). These were the only scripts edited today still missing the guard.

Checkpoint scripts (#100) and suspend-bitlocker (#101) already carry this gate.

## Not changed
Core-isolation logic, exit codes, and their (reverted) `$RMM` style are untouched apart from the guard.

## ⚠️ Deployment
As always, merging does not update NinjaOne — deployed copies must be refreshed from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)